### PR TITLE
Fix: Correct routing to resolve broken links on landing page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,10 +28,12 @@ const App = () => (
         <Sonner />
         <BrowserRouter>
           <Routes>
-            <Route path="/auth" element={<Auth />} />
+            {/* Public pages */}
             <Route path="/" element={<Index />} />
+            <Route path="/auth" element={<Auth />} />
             <Route path="/agendar/:establishmentId" element={<PublicBooking />} />
-            <Route path="/:slug" element={<PublicBooking />} />
+
+            {/* Internal pages (with sidebar) */}
             <Route element={<AppLayout />}>
               <Route path="/dashboard" element={<Dashboard />} />
               <Route path="/clients" element={<Clients />} />
@@ -41,9 +43,13 @@ const App = () => (
               <Route path="/reports" element={<Reports />} />
               <Route path="/metrics" element={<Metrics />} />
               <Route path="/settings" element={<Settings />} />
-              {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-              <Route path="*" element={<NotFound />} />
             </Route>
+
+            {/* Dynamic public page, must be after other routes */}
+            <Route path="/:slug" element={<PublicBooking />} />
+
+            {/* Catch-all Not Found page */}
+            <Route path="*" element={<NotFound />} />
           </Routes>
         </BrowserRouter>
       </AuthProvider>


### PR DESCRIPTION
This commit refactors the routing structure in `src/App.tsx` to resolve an issue where buttons on the landing page were leading to an error page.

The dynamic route `/:slug` was incorrectly matching static paths like `/auth`. By reordering the routes and placing the more specific static paths before the general dynamic path, this conflict is resolved.

Additionally, the `NotFound` route (`*`) has been moved to the top level to ensure it renders without the main application layout.