### PR TITLE
Handle auth loading state in SuperAdmin and show skeleton while resolving user/roles

### DIFF
--- a/src/pages/SuperAdmin.tsx
+++ b/src/pages/SuperAdmin.tsx
@@ -33,7 +33,7 @@ const TABS: { id: Tab; label: string; icon: typeof LayoutDashboard }[] = [
 ];
 
 export default function SuperAdmin() {
-  const { user } = useAuth();
+  const { user, loading } = useAuth();
   const navigate = useNavigate();
   const [tab, setTab] = useState<Tab>("dashboard");
 
@@ -42,12 +42,22 @@ export default function SuperAdmin() {
   }, []);
 
   useEffect(() => {
-    if (!user) navigate("/auth");
-  }, [user, navigate]);
+    if (!loading && !user) navigate("/auth");
+  }, [loading, user, navigate]);
+
+  if (loading) {
+    return (
+      <main className="p-4 md:p-6 space-y-4">
+        <Skeleton className="h-10 w-64" />
+        <Skeleton className="h-28" />
+        <Skeleton className="h-64" />
+      </main>
+    );
+  }
 
   const { data: roles, isLoading } = useQuery({
     queryKey: ["roles", user?.id],
-    enabled: !!user,
+    enabled: !loading && !!user,
     queryFn: async () => {
       const { data, error } = await supabase
         .from("user_roles")


### PR DESCRIPTION
### Motivation

- Prevent redirecting to `/auth` before the authentication state has resolved to avoid flicker and incorrect navigation.
- Avoid triggering the roles query before the `useAuth` hook has finished loading to prevent unnecessary or failing requests.
- Provide a visual placeholder while auth/roles are loading so users see a stable loading state instead of a blank page.

### Description

- Read `loading` from `useAuth` and update the redirect `useEffect` to only navigate when `!loading && !user`.
- Return a set of `Skeleton` placeholders while `loading` is true to render a consistent loading UI for the page.
- Change the `useQuery` `enabled` flag to `!loading && !!user` so the roles query only runs after auth is resolved.

### Testing

- Ran TypeScript type-check with `tsc --noEmit`; the type-check passed.
- Ran the unit test suite with `yarn test`; tests passed.
- Performed a production build with `yarn build` to validate bundling; the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d2686dd24832f8d547e02d80dfdb9)