### PR TITLE
Load user profile on auth changes and add loading state UI for SuperAdmin

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -30,6 +30,20 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [loading, setLoading] = useState(true);
   const { toast } = useToast();
 
+  const fetchProfile = async (userId: string) => {
+    try {
+      const { data: profileData } = await supabase
+        .from('profiles')
+        .select('*')
+        .eq('user_id', userId)
+        .single();
+      setProfile(profileData);
+    } catch (error) {
+      console.error('Error fetching profile:', error);
+      setProfile(null);
+    }
+  };
+
   useEffect(() => {
     // Set up auth state listener FIRST
     const { data: { subscription } } = supabase.auth.onAuthStateChange(
@@ -40,18 +54,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         // Defer profile fetching with setTimeout to prevent deadlock
         if (session?.user) {
           setTimeout(async () => {
-            try {
-              console.log('Fetching profile for user:', session.user.id);
-              const { data: profileData } = await supabase
-                .from('profiles')
-                .select('*')
-                .eq('user_id', session.user.id)
-                .single();
-              console.log('Profile data:', profileData);
-              setProfile(profileData);
-            } catch (error) {
-              console.error('Error fetching profile:', error);
-            }
+            await fetchProfile(session.user.id);
           }, 0);
         } else {
           setProfile(null);
@@ -62,12 +65,13 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     );
 
     // THEN check for existing session
-    supabase.auth.getSession().then(({ data: { session } }) => {
+    supabase.auth.getSession().then(async ({ data: { session } }) => {
       setSession(session);
       setUser(session?.user ?? null);
-      if (!session) {
-        setLoading(false);
+      if (session?.user) {
+        await fetchProfile(session.user.id);
       }
+      setLoading(false);
     });
 
     return () => subscription.unsubscribe();

--- a/src/pages/SuperAdmin.tsx
+++ b/src/pages/SuperAdmin.tsx
@@ -33,7 +33,7 @@ const TABS: { id: Tab; label: string; icon: typeof LayoutDashboard }[] = [
 ];
 
 export default function SuperAdmin() {
-  const { user } = useAuth();
+  const { user, loading } = useAuth();
   const navigate = useNavigate();
   const [tab, setTab] = useState<Tab>("dashboard");
 
@@ -42,12 +42,22 @@ export default function SuperAdmin() {
   }, []);
 
   useEffect(() => {
-    if (!user) navigate("/auth");
-  }, [user, navigate]);
+    if (!loading && !user) navigate("/auth");
+  }, [loading, user, navigate]);
+
+  if (loading) {
+    return (
+      <main className="p-4 md:p-6 space-y-4">
+        <Skeleton className="h-10 w-64" />
+        <Skeleton className="h-28" />
+        <Skeleton className="h-64" />
+      </main>
+    );
+  }
 
   const { data: roles, isLoading } = useQuery({
     queryKey: ["roles", user?.id],
-    enabled: !!user,
+    enabled: !loading && !!user,
     queryFn: async () => {
       const { data, error } = await supabase
         .from("user_roles")


### PR DESCRIPTION
### Motivation

- Ensure user profile is fetched reliably after authentication state changes and avoid potential deadlocks when accessing Supabase from the auth listener.  
- Prevent SuperAdmin page from redirecting before auth initialization completes and provide a loading UI while auth state is being resolved.  

### Description

- Added a reusable `fetchProfile(userId: string)` helper in `src/hooks/useAuth.tsx` to centralize profile fetching and error handling.  
- Refactored the `supabase.auth.onAuthStateChange` listener to defer profile fetching with `setTimeout` and call the new `fetchProfile` helper.  
- Updated the initial `supabase.auth.getSession()` check to be `async` and fetch the profile when a session user exists before clearing the loading flag.  
- In `src/pages/SuperAdmin.tsx` added `loading` from `useAuth`, adjusted the redirect guard to wait for auth initialization, disabled the roles query until auth is ready, and render `Skeleton` placeholders while `loading` is true.  

### Testing

- Performed TypeScript type-check and project build with `yarn build`, which completed successfully.  
- Verified the SuperAdmin page displays the loading skeleton and no redirect occurs while auth state is initializing in a local dev run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d2686dd24832f8d547e02d80dfdb9)