### PR TITLE
Add expanded signup profile fields, DB migration, and profile loading improvements

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -30,6 +30,20 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [loading, setLoading] = useState(true);
   const { toast } = useToast();
 
+  const fetchProfile = async (userId: string) => {
+    try {
+      const { data: profileData } = await supabase
+        .from('profiles')
+        .select('*')
+        .eq('user_id', userId)
+        .single();
+      setProfile(profileData);
+    } catch (error) {
+      console.error('Error fetching profile:', error);
+      setProfile(null);
+    }
+  };
+
   useEffect(() => {
     // Set up auth state listener FIRST
     const { data: { subscription } } = supabase.auth.onAuthStateChange(
@@ -40,18 +54,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         // Defer profile fetching with setTimeout to prevent deadlock
         if (session?.user) {
           setTimeout(async () => {
-            try {
-              console.log('Fetching profile for user:', session.user.id);
-              const { data: profileData } = await supabase
-                .from('profiles')
-                .select('*')
-                .eq('user_id', session.user.id)
-                .single();
-              console.log('Profile data:', profileData);
-              setProfile(profileData);
-            } catch (error) {
-              console.error('Error fetching profile:', error);
-            }
+            await fetchProfile(session.user.id);
           }, 0);
         } else {
           setProfile(null);
@@ -62,12 +65,13 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     );
 
     // THEN check for existing session
-    supabase.auth.getSession().then(({ data: { session } }) => {
+    supabase.auth.getSession().then(async ({ data: { session } }) => {
       setSession(session);
       setUser(session?.user ?? null);
-      if (!session) {
-        setLoading(false);
+      if (session?.user) {
+        await fetchProfile(session.user.id);
       }
+      setLoading(false);
     });
 
     return () => subscription.unsubscribe();

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -331,48 +331,63 @@ export type Database = {
         Row: {
           accepting_bookings: boolean
           business_name: string
-          city: string | null
+          business_type: string
+          cep: string
+          city: string
           created_at: string
+          document: string
           email: string
           id: string
           last_access_at: string | null
+          neighborhood: string
           owner_name: string
           phone: string
           plan: string | null
           slug: string | null
           status: string | null
+          street: string
           updated_at: string
           user_id: string
         }
         Insert: {
           accepting_bookings?: boolean
           business_name: string
-          city?: string | null
+          business_type: string
+          cep: string
+          city: string
           created_at?: string
+          document: string
           email: string
           id?: string
           last_access_at?: string | null
+          neighborhood: string
           owner_name: string
           phone: string
           plan?: string | null
           slug?: string | null
           status?: string | null
+          street: string
           updated_at?: string
           user_id: string
         }
         Update: {
           accepting_bookings?: boolean
           business_name?: string
-          city?: string | null
+          business_type?: string
+          cep?: string
+          city?: string
           created_at?: string
+          document?: string
           email?: string
           id?: string
           last_access_at?: string | null
+          neighborhood?: string
           owner_name?: string
           phone?: string
           plan?: string | null
           slug?: string | null
           status?: string | null
+          street?: string
           updated_at?: string
           user_id?: string
         }

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -20,8 +20,14 @@ const Auth = () => {
     email: '',
     password: '',
     businessName: '',
+    document: '',
     ownerName: '',
     phone: '',
+    cep: '',
+    street: '',
+    neighborhood: '',
+    city: '',
+    businessType: '',
   });
 
   const [searchParams] = useSearchParams();
@@ -44,8 +50,14 @@ const Auth = () => {
     setIsLoading(true);
     await signUp(signupData.email, signupData.password, {
       business_name: signupData.businessName,
+      document: signupData.document,
       owner_name: signupData.ownerName,
       phone: signupData.phone,
+      cep: signupData.cep,
+      street: signupData.street,
+      neighborhood: signupData.neighborhood,
+      city: signupData.city,
+      business_type: signupData.businessType,
     });
     setIsLoading(false);
   };
@@ -113,6 +125,15 @@ const Auth = () => {
                   />
                 </div>
                 <div className="space-y-2">
+                  <Label htmlFor="document">CPF ou CNPJ</Label>
+                  <Input
+                    id="document"
+                    value={signupData.document}
+                    onChange={(e) => setSignupData({ ...signupData, document: e.target.value })}
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
                   <Label htmlFor="owner-name">Nome do Proprietário</Label>
                   <Input
                     id="owner-name"
@@ -129,6 +150,59 @@ const Auth = () => {
                     onChange={(e) => setSignupData({ ...signupData, phone: e.target.value })}
                     required
                   />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="cep">CEP</Label>
+                  <Input
+                    id="cep"
+                    value={signupData.cep}
+                    onChange={(e) => setSignupData({ ...signupData, cep: e.target.value })}
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="street">Rua</Label>
+                  <Input
+                    id="street"
+                    value={signupData.street}
+                    onChange={(e) => setSignupData({ ...signupData, street: e.target.value })}
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="neighborhood">Bairro</Label>
+                  <Input
+                    id="neighborhood"
+                    value={signupData.neighborhood}
+                    onChange={(e) => setSignupData({ ...signupData, neighborhood: e.target.value })}
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="city">Cidade</Label>
+                  <Input
+                    id="city"
+                    value={signupData.city}
+                    onChange={(e) => setSignupData({ ...signupData, city: e.target.value })}
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="business-type">Tipo de comércio</Label>
+                  <select
+                    id="business-type"
+                    value={signupData.businessType}
+                    onChange={(e) => setSignupData({ ...signupData, businessType: e.target.value })}
+                    required
+                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                  >
+                    <option value="" disabled>Selecione...</option>
+                    <option value="Salao de beleza">Salão de beleza</option>
+                    <option value="Barbeiro">Barbeiro</option>
+                    <option value="Clinica Estetica">Clinica Estética</option>
+                    <option value="Trancista">Trancista</option>
+                    <option value="Manicure">Manicure</option>
+                  </select>
                 </div>
                 <div className="space-y-2">
                   <Label htmlFor="signup-email">Email</Label>

--- a/src/pages/SuperAdmin.tsx
+++ b/src/pages/SuperAdmin.tsx
@@ -33,7 +33,7 @@ const TABS: { id: Tab; label: string; icon: typeof LayoutDashboard }[] = [
 ];
 
 export default function SuperAdmin() {
-  const { user } = useAuth();
+  const { user, loading } = useAuth();
   const navigate = useNavigate();
   const [tab, setTab] = useState<Tab>("dashboard");
 
@@ -42,12 +42,22 @@ export default function SuperAdmin() {
   }, []);
 
   useEffect(() => {
-    if (!user) navigate("/auth");
-  }, [user, navigate]);
+    if (!loading && !user) navigate("/auth");
+  }, [loading, user, navigate]);
+
+  if (loading) {
+    return (
+      <main className="p-4 md:p-6 space-y-4">
+        <Skeleton className="h-10 w-64" />
+        <Skeleton className="h-28" />
+        <Skeleton className="h-64" />
+      </main>
+    );
+  }
 
   const { data: roles, isLoading } = useQuery({
     queryKey: ["roles", user?.id],
-    enabled: !!user,
+    enabled: !loading && !!user,
     queryFn: async () => {
       const { data, error } = await supabase
         .from("user_roles")

--- a/supabase/migrations/20260520121000_expand_signup_profile_fields.sql
+++ b/supabase/migrations/20260520121000_expand_signup_profile_fields.sql
@@ -1,0 +1,65 @@
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS document TEXT,
+  ADD COLUMN IF NOT EXISTS cep TEXT,
+  ADD COLUMN IF NOT EXISTS street TEXT,
+  ADD COLUMN IF NOT EXISTS neighborhood TEXT,
+  ADD COLUMN IF NOT EXISTS business_type TEXT;
+
+UPDATE public.profiles
+SET
+  document = COALESCE(NULLIF(document, ''), 'PENDENTE'),
+  cep = COALESCE(NULLIF(cep, ''), 'PENDENTE'),
+  street = COALESCE(NULLIF(street, ''), 'PENDENTE'),
+  neighborhood = COALESCE(NULLIF(neighborhood, ''), 'PENDENTE'),
+  city = COALESCE(NULLIF(city, ''), 'PENDENTE'),
+  business_type = COALESCE(NULLIF(business_type, ''), 'Salao de beleza')
+WHERE
+  document IS NULL OR cep IS NULL OR street IS NULL OR neighborhood IS NULL OR city IS NULL OR business_type IS NULL
+  OR document = '' OR cep = '' OR street = '' OR neighborhood = '' OR city = '' OR business_type = '';
+
+ALTER TABLE public.profiles
+  ALTER COLUMN document SET NOT NULL,
+  ALTER COLUMN cep SET NOT NULL,
+  ALTER COLUMN street SET NOT NULL,
+  ALTER COLUMN neighborhood SET NOT NULL,
+  ALTER COLUMN city SET NOT NULL,
+  ALTER COLUMN business_type SET NOT NULL;
+
+ALTER TABLE public.profiles
+  ADD CONSTRAINT profiles_business_type_check
+  CHECK (business_type IN ('Salao de beleza', 'Barbeiro', 'Clinica Estetica', 'Trancista', 'Manicure'));
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER SET search_path = 'public'
+AS $$
+BEGIN
+  INSERT INTO public.profiles (
+    user_id,
+    business_name,
+    document,
+    owner_name,
+    phone,
+    email,
+    cep,
+    street,
+    neighborhood,
+    city,
+    business_type
+  )
+  VALUES (
+    NEW.id,
+    COALESCE(NEW.raw_user_meta_data ->> 'business_name', 'Meu Salão'),
+    COALESCE(NULLIF(NEW.raw_user_meta_data ->> 'document', ''), 'PENDENTE'),
+    COALESCE(NEW.raw_user_meta_data ->> 'owner_name', NEW.raw_user_meta_data ->> 'full_name', 'Proprietário'),
+    COALESCE(NEW.raw_user_meta_data ->> 'phone', NEW.phone, ''),
+    NEW.email,
+    COALESCE(NULLIF(NEW.raw_user_meta_data ->> 'cep', ''), 'PENDENTE'),
+    COALESCE(NULLIF(NEW.raw_user_meta_data ->> 'street', ''), 'PENDENTE'),
+    COALESCE(NULLIF(NEW.raw_user_meta_data ->> 'neighborhood', ''), 'PENDENTE'),
+    COALESCE(NULLIF(NEW.raw_user_meta_data ->> 'city', ''), 'PENDENTE'),
+    COALESCE(NULLIF(NEW.raw_user_meta_data ->> 'business_type', ''), 'Salao de beleza')
+  );
+  INSERT INTO public.user_roles (user_id, role) VALUES (NEW.id, 'establishment');
+  RETURN NEW;
+END;
+$$;


### PR DESCRIPTION
### Motivation
- Expand the profile model and signup flow to collect business details (address, document, business type) so new establishments have richer stored data. 
- Ensure the client keeps profile state in sync after auth events and initial session checks to avoid race conditions when reading profiles. 
- Add a DB migration to add and populate new profile columns with constraints and ensure new users get a profile row and an initial role.

### Description
- Added `fetchProfile` to `src/hooks/useAuth.tsx` and refactored auth listeners to call it from `onAuthStateChange` and initial `getSession` handling to reliably load `profile` and avoid deadlocks. 
- Extended the `profiles` TypeScript types in `src/integrations/supabase/types.ts` to include `document`, `cep`, `street`, `neighborhood`, and `business_type` and adjusted `Insert`/`Update` shapes. 
- Updated `src/pages/Auth.tsx` signup UI and payload to collect and send the new fields (`document`, `cep`, `street`, `neighborhood`, `city`, `businessType`) to `signUp`. 
- Added SQL migration `supabase/migrations/20260520121000_expand_signup_profile_fields.sql` to add the new columns, backfill defaults, set `NOT NULL`, add a `CHECK` constraint for `business_type`, and create `handle_new_user()` trigger function to insert profile rows and a default `establishment` role for new users. 
- Improved `src/pages/SuperAdmin.tsx` to wait for auth `loading` before redirecting, to enable role queries only when ready, and to render skeleton placeholders while loading.

### Testing
- Performed a TypeScript typecheck with `tsc --noEmit`, which succeeded. 
- No automated unit test changes were added for this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d2686dd24832f8d547e02d80dfdb9)