### PR TITLE
Include establishment_id in appointments query to fix RLS error on start

### DIFF
--- a/src/pages/components/AgendaContent.tsx
+++ b/src/pages/components/AgendaContent.tsx
@@ -37,7 +37,7 @@ export default function AgendaContent() {
     enabled: !!establishmentId,
     queryFn: async () => {
       const [apptRes, servicesRes, profRes, clientsRes] = await Promise.all([
-        supabase.from("appointments").select("id, appointment_date, status, notes, client_id, service_id, professional_id")
+        supabase.from("appointments").select("id, establishment_id, appointment_date, status, notes, client_id, service_id, professional_id")
           .eq("establishment_id", establishmentId)
           .gte("appointment_date", range.start.toISOString())
           .lte("appointment_date", range.end.toISOString())


### PR DESCRIPTION
### Motivation
- Starting an appointment from the agenda should open a `comandas` row tied to the correct establishment, but the appointment object lacked `establishment_id` and caused RLS failures when inserting into `comandas`.

### Description
- Add `establishment_id` to the `select` projection for appointments in `src/pages/components/AgendaContent.tsx` so `ensureComandaForAppointment` receives a valid `establishment_id` when starting a service.

### Testing
- Verified the code diff shows the new field included in the `select` call for appointments (`select("id, establishment_id, appointment_date, status, ...")`).
- Ran `npm run -s lint` which failed due to a missing ESLint dependency (`@eslint/js`) in the local environment, so lint could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1618100e48832f839f428863310ce5)