### PR TITLE
Add multi-role staff access: DB migration, auth role tracking, and role-aware UI

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -62,7 +62,8 @@ const groups = [
 
 export default function AppSidebar() {
   const location = useLocation();
-  const { signOut } = useAuth();
+  const { signOut, establishmentRole } = useAuth();
+  const isEmployee = establishmentRole === "employee";
 
   const isActive = (path: string) => location.pathname === path;
 
@@ -85,14 +86,17 @@ export default function AppSidebar() {
       </SidebarHeader>
 
       <SidebarContent>
-        {groups.map((group) => (
+        {groups.map((group) => {
+          const filteredItems = group.items.filter((item) => !isEmployee || ["/agenda", "/atendimentos", "/sales"].includes(item.url));
+          if (!filteredItems.length) return null;
+          return (
           <SidebarGroup key={group.label}>
             <SidebarGroupLabel className="text-[10px] uppercase tracking-wider font-semibold text-sidebar-foreground/40">
               {group.label}
             </SidebarGroupLabel>
             <SidebarGroupContent>
               <SidebarMenu>
-                {group.items.map((item) => {
+                {filteredItems.map((item) => {
                   const active = isActive(item.url);
                   return (
                     <SidebarMenuItem key={item.title}>
@@ -116,7 +120,8 @@ export default function AppSidebar() {
               </SidebarMenu>
             </SidebarGroupContent>
           </SidebarGroup>
-        ))}
+        );
+        })}
       </SidebarContent>
 
       <SidebarSeparator />

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -4,6 +4,8 @@ import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 
 interface AuthContextType {
+  establishmentRole: "owner" | "admin" | "employee" | null;
+  professionalId: string | null;
   user: User | null;
   session: Session | null;
   profile: any | null;
@@ -28,19 +30,50 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [session, setSession] = useState<Session | null>(null);
   const [profile, setProfile] = useState<any | null>(null);
   const [loading, setLoading] = useState(true);
+  const [establishmentRole, setEstablishmentRole] = useState<"owner" | "admin" | "employee" | null>(null);
+  const [professionalId, setProfessionalId] = useState<string | null>(null);
   const { toast } = useToast();
 
   const fetchProfile = async (userId: string) => {
     try {
-      const { data: profileData } = await supabase
+      const { data: ownerProfile } = await supabase
         .from('profiles')
         .select('*')
         .eq('user_id', userId)
-        .single();
-      setProfile(profileData);
+        .maybeSingle();
+      if (ownerProfile) {
+        setProfile(ownerProfile);
+        setEstablishmentRole("owner");
+        setProfessionalId(null);
+        return;
+      }
+
+      const { data: membership } = await supabase
+        .from('establishment_users' as any)
+        .select('role, professional_id, establishment_id')
+        .eq('user_id', userId)
+        .eq('active', true)
+        .maybeSingle();
+      if (!membership?.establishment_id) {
+        setProfile(null);
+        setEstablishmentRole(null);
+        setProfessionalId(null);
+        return;
+      }
+
+      const { data: linkedProfile } = await supabase
+        .from('profiles')
+        .select('*')
+        .eq('id', membership.establishment_id)
+        .maybeSingle();
+      setProfile(linkedProfile ?? null);
+      setEstablishmentRole((membership.role as any) ?? null);
+      setProfessionalId(membership.professional_id ?? null);
     } catch (error) {
       console.error('Error fetching profile:', error);
       setProfile(null);
+      setEstablishmentRole(null);
+      setProfessionalId(null);
     }
   };
 
@@ -58,6 +91,8 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
           }, 0);
         } else {
           setProfile(null);
+          setEstablishmentRole(null);
+          setProfessionalId(null);
         }
         
         setLoading(false);
@@ -127,6 +162,8 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     setUser(null);
     setSession(null);
     setProfile(null);
+    setEstablishmentRole(null);
+    setProfessionalId(null);
     toast({
       title: "Logout realizado",
       description: "Você foi desconectado com sucesso.",
@@ -141,6 +178,8 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     signIn,
     signOut,
     loading,
+    establishmentRole,
+    professionalId,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/pages/components/AgendaContent.tsx
+++ b/src/pages/components/AgendaContent.tsx
@@ -37,7 +37,7 @@ export default function AgendaContent() {
     enabled: !!establishmentId,
     queryFn: async () => {
       const [apptRes, servicesRes, profRes, clientsRes] = await Promise.all([
-        supabase.from("appointments").select("id, appointment_date, status, notes, client_id, service_id, professional_id")
+        supabase.from("appointments").select("id, establishment_id, appointment_date, status, notes, client_id, service_id, professional_id")
           .eq("establishment_id", establishmentId)
           .gte("appointment_date", range.start.toISOString())
           .lte("appointment_date", range.end.toISOString())

--- a/supabase/migrations/20260526230000_staff_access_layers.sql
+++ b/supabase/migrations/20260526230000_staff_access_layers.sql
@@ -1,0 +1,139 @@
+-- Multi-access layers for establishments (owner/admin/employee)
+DO $$ BEGIN
+  CREATE TYPE public.establishment_access_role AS ENUM ('admin', 'employee');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS public.establishment_users (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  establishment_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  role public.establishment_access_role NOT NULL DEFAULT 'employee',
+  professional_id UUID NULL REFERENCES public.professionals(id) ON DELETE SET NULL,
+  active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (establishment_id, user_id)
+);
+
+ALTER TABLE public.establishment_users ENABLE ROW LEVEL SECURITY;
+
+CREATE OR REPLACE FUNCTION public.current_establishment_id()
+RETURNS UUID
+LANGUAGE SQL
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT p.id FROM public.profiles p WHERE p.user_id = auth.uid()
+  UNION
+  SELECT eu.establishment_id FROM public.establishment_users eu WHERE eu.user_id = auth.uid() AND eu.active = true
+  LIMIT 1
+$$;
+
+CREATE OR REPLACE FUNCTION public.current_establishment_role()
+RETURNS TEXT
+LANGUAGE SQL
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT 'owner'::text FROM public.profiles p WHERE p.user_id = auth.uid()
+  UNION
+  SELECT eu.role::text FROM public.establishment_users eu WHERE eu.user_id = auth.uid() AND eu.active = true
+  LIMIT 1
+$$;
+
+CREATE OR REPLACE FUNCTION public.current_professional_id()
+RETURNS UUID
+LANGUAGE SQL
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT eu.professional_id FROM public.establishment_users eu WHERE eu.user_id = auth.uid() AND eu.active = true LIMIT 1
+$$;
+
+CREATE POLICY "Owners/admins manage establishment users"
+ON public.establishment_users FOR ALL TO authenticated
+USING (
+  establishment_id IN (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+  OR EXISTS (
+    SELECT 1 FROM public.establishment_users me
+    WHERE me.establishment_id = establishment_users.establishment_id
+      AND me.user_id = auth.uid()
+      AND me.role = 'admin'
+      AND me.active = true
+  )
+)
+WITH CHECK (
+  establishment_id IN (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+  OR EXISTS (
+    SELECT 1 FROM public.establishment_users me
+    WHERE me.establishment_id = establishment_users.establishment_id
+      AND me.user_id = auth.uid()
+      AND me.role = 'admin'
+      AND me.active = true
+  )
+);
+
+CREATE POLICY "Users can view own membership"
+ON public.establishment_users FOR SELECT TO authenticated
+USING (user_id = auth.uid());
+
+-- Policies for employee access
+CREATE POLICY "Staff can view linked establishment profile"
+ON public.profiles FOR SELECT TO authenticated
+USING (id = public.current_establishment_id());
+
+CREATE POLICY "Staff can view base catalog"
+ON public.clients FOR SELECT TO authenticated
+USING (establishment_id = public.current_establishment_id());
+CREATE POLICY "Staff can view services"
+ON public.services FOR SELECT TO authenticated
+USING (establishment_id = public.current_establishment_id());
+CREATE POLICY "Staff can view professionals"
+ON public.professionals FOR SELECT TO authenticated
+USING (establishment_id = public.current_establishment_id());
+
+CREATE POLICY "Staff can manage own appointments"
+ON public.appointments FOR ALL TO authenticated
+USING (
+  establishment_id = public.current_establishment_id()
+  AND (
+    public.current_establishment_role() IN ('owner', 'admin')
+    OR professional_id = public.current_professional_id()
+  )
+)
+WITH CHECK (
+  establishment_id = public.current_establishment_id()
+  AND (
+    public.current_establishment_role() IN ('owner', 'admin')
+    OR professional_id = public.current_professional_id()
+  )
+);
+
+CREATE POLICY "Staff can manage own sales"
+ON public.sales FOR ALL TO authenticated
+USING (
+  establishment_id = public.current_establishment_id()
+  AND (
+    public.current_establishment_role() IN ('owner', 'admin')
+    OR professional_id = public.current_professional_id()
+  )
+)
+WITH CHECK (
+  establishment_id = public.current_establishment_id()
+  AND (
+    public.current_establishment_role() IN ('owner', 'admin')
+    OR professional_id = public.current_professional_id()
+  )
+);
+
+CREATE POLICY "Staff can manage own comandas"
+ON public.comandas FOR ALL TO authenticated
+USING (establishment_id = public.current_establishment_id())
+WITH CHECK (establishment_id = public.current_establishment_id());
+
+CREATE POLICY "Staff can manage own comanda_items"
+ON public.comanda_items FOR ALL TO authenticated
+USING (establishment_id = public.current_establishment_id())
+WITH CHECK (establishment_id = public.current_establishment_id());


### PR DESCRIPTION
### Motivation
- Introduce multi-layer staff access (owner/admin/employee) and enforce it at the database and application level to limit employee access to certain features.
- Surface the current establishment role and professional linkage in the client to enable role-aware UI and permission checks.

### Description
- Add a new Supabase migration `20260526230000_staff_access_layers.sql` that creates `establishment_users`, role enum, helper functions (`current_establishment_id`, `current_establishment_role`, `current_professional_id`) and RLS policies for profiles, clients, services, professionals, appointments, sales, comandas and comanda_items.
- Extend the auth context in `useAuth.tsx` to expose `establishmentRole` and `professionalId`, update `fetchProfile` to detect owner vs membership and populate these values, and clear them on sign-out or error.
- Update `AppSidebar.tsx` to make the sidebar role-aware by hiding non-essential menu items for users with `establishmentRole === "employee"` and only showing a reduced set of routes for employees.
- Update `AgendaContent.tsx` query to include `establishment_id` in the appointments select to align with the new RLS and data model.

### Testing
- Ran TypeScript type-check and project build (`yarn build`) and they completed successfully.
- Ran the existing automated test suite (`yarn test`) and all tests passed.
- Verified the migration SQL compiles and added to the migrations directory for deployment, with no runtime verification in CI for the DB policies included.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1618100e48832f839f428863310ce5)