### PR TITLE
Fix day agenda range filtering

### DIFF
--- a/src/components/agenda/AgendaCalendar.tsx
+++ b/src/components/agenda/AgendaCalendar.tsx
@@ -16,6 +16,16 @@ const MESSAGES = {
   showMore: (n: number) => `+ ver mais (${n})`,
 };
 
+const toFullDayRange = (start: Date, end: Date) => {
+  const startDate = new Date(start);
+  startDate.setHours(0, 0, 0, 0);
+
+  const endDate = new Date(end);
+  endDate.setHours(23, 59, 59, 999);
+
+  return { start: startDate, end: endDate };
+};
+
 export interface AgendaEvent {
   id: string;
   title: string;
@@ -73,10 +83,10 @@ export function AgendaCalendar({ events, onSelectSlot, onSelectEvent, onRangeCha
         onSelectEvent={(e) => onSelectEvent(e as AgendaEvent)}
         onDrillDown={(d) => { setDate(d); setView("day"); }}
         onRangeChange={(range: any) => {
-          if (Array.isArray(range)) {
-            onRangeChange?.({ start: range[0], end: range[range.length - 1] });
+          if (Array.isArray(range) && range.length > 0) {
+            onRangeChange?.(toFullDayRange(range[0], range[range.length - 1]));
           } else if (range?.start && range?.end) {
-            onRangeChange?.({ start: range.start, end: range.end });
+            onRangeChange?.(toFullDayRange(range.start, range.end));
           }
         }}
         style={{ height: 680 }}


### PR DESCRIPTION
### Motivation
- The calendar was passing exact range boundaries from `react-big-calendar` which could exclude appointments later in the day when querying the backend, causing the "Dia"/day agenda to appear empty.

### Description
- Add a `toFullDayRange` helper that normalizes a start/end to full-day bounds (`00:00:00.000` → `23:59:59.999`) in `src/components/agenda/AgendaCalendar.tsx`.
- Use `toFullDayRange` for both array and object shapes returned by `onRangeChange` so day/week/month/agenda views produce full-day ranges.
- Keep behavior confined to the calendar component so other parts of the code consume consistent full-day ranges.

### Testing
- `git diff --check` executed successfully and showed the intended file changes in `src/components/agenda/AgendaCalendar.tsx`.
- `npm run lint` was attempted but failed due to missing or unresolved dev dependencies (`@eslint/js`) in the environment.
- `npm run build` was attempted but failed because `vite` is not available in the environment.
- `npm ci` was attempted but failed because `package-lock.json` is out of sync with `package.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19a9a1d8d4832fb2e36f9bd9365c1b)