### PR TITLE
Fix super admin subscription visibility and add potential revenue metric

### DIFF
--- a/src/components/admin/AdminCompanies.tsx
+++ b/src/components/admin/AdminCompanies.tsx
@@ -22,6 +22,7 @@ type Row = {
   phone: string;
   created_at: string;
   last_access_at: string | null;
+  selected_plan_slug?: string | null;
   subscription?: {
     id: string;
     status: string;
@@ -29,6 +30,7 @@ type Row = {
     monthly_amount: number;
     next_billing_at: string | null;
     asaas_subscription_id: string | null;
+    inferred?: boolean;
     plan?: { name: string };
   };
 
@@ -51,15 +53,21 @@ export default function AdminCompanies() {
   const profilesQuery = useQuery({
     queryKey: ["admin-companies"],
     queryFn: async () => {
-      const { data: profiles, error } = await supabase
+      const { data: profiles, error } = await (supabase as any)
         .from("profiles")
-        .select("id, business_name, owner_name, email, phone, created_at, last_access_at")
+        .select("id, business_name, owner_name, email, phone, created_at, last_access_at, selected_plan_slug")
         .order("created_at", { ascending: false });
       if (error) throw error;
 
-      const { data: subs } = await (supabase as any)
-        .from("subscriptions")
-        .select("id, establishment_id, status, plan_id, monthly_amount, next_billing_at, asaas_subscription_id, subscription_plans(name)");
+      const [{ data: subs }, { data: fetchedPlans }] = await Promise.all([
+        (supabase as any)
+          .from("subscriptions")
+          .select("id, establishment_id, status, plan_id, monthly_amount, next_billing_at, asaas_subscription_id, subscription_plans(name)"),
+        (supabase as any)
+          .from("subscription_plans")
+          .select("id, name, slug, monthly_price")
+          .eq("active", true),
+      ]);
       const subsMap = new Map<string, any>();
       (subs ?? []).forEach((s: any) => {
         subsMap.set(s.establishment_id, {
@@ -73,7 +81,36 @@ export default function AdminCompanies() {
         });
       });
 
-      return (profiles ?? []).map((p: any) => ({ ...p, subscription: subsMap.get(p.id) })) as Row[];
+      const plansBySlug = new Map<string, { id: string; name: string; slug: string; monthly_price: number }>();
+      (fetchedPlans ?? []).forEach((p: any) => plansBySlug.set(p.slug, p));
+
+      return (profiles ?? []).map((p: any) => {
+        const subscription = subsMap.get(p.id);
+        const chosenPlan = p.selected_plan_slug ? plansBySlug.get(p.selected_plan_slug) : undefined;
+        if (subscription) {
+          return {
+            ...p,
+            subscription: {
+              ...subscription,
+              plan: subscription.plan ?? (chosenPlan ? { name: chosenPlan.name } : undefined),
+              monthly_amount: Number(subscription.monthly_amount || chosenPlan?.monthly_price || 0),
+            },
+          };
+        }
+        return {
+          ...p,
+          subscription: {
+            id: `profile-${p.id}`,
+            status: "trial",
+            plan_id: chosenPlan?.id ?? null,
+            monthly_amount: Number(chosenPlan?.monthly_price || 0),
+            next_billing_at: null,
+            asaas_subscription_id: null,
+            inferred: true,
+            plan: chosenPlan ? { name: chosenPlan.name } : undefined,
+          },
+        };
+      }) as Row[];
     },
   });
 
@@ -82,11 +119,11 @@ export default function AdminCompanies() {
     queryFn: async () => {
       const { data, error } = await (supabase as any)
         .from("subscription_plans")
-        .select("id, name, monthly_price")
+        .select("id, name, slug, monthly_price")
         .eq("active", true)
         .order("display_order");
       if (error) throw error;
-      return data as { id: string; name: string; monthly_price: number }[];
+      return data as { id: string; name: string; slug: string; monthly_price: number }[];
     },
   });
 
@@ -107,7 +144,7 @@ export default function AdminCompanies() {
     });
   }, [profilesQuery.data, search, statusFilter, planFilter]);
   async function changeStatus(row: Row, status: string, action: string) {
-    if (!row.subscription) return;
+    if (!row.subscription || row.subscription.inferred) return;
     const updates: any = { status };
     if (status === "canceled" || status === "blocked") updates.canceled_at = new Date().toISOString();
     const { error } = await (supabase as any)
@@ -138,7 +175,7 @@ export default function AdminCompanies() {
   }
 
   function openBilling(row: Row) {
-    if (!row.subscription) return;
+    if (!row.subscription || row.subscription.inferred) return;
     setBillingTarget(row);
     setBillingStatus(row.subscription.status || "active");
     setBillingAmount(String(row.subscription.monthly_amount || ""));
@@ -182,15 +219,26 @@ export default function AdminCompanies() {
     if (!editTarget?.subscription || !editPlan) return;
     const plan = plansQuery.data?.find((p) => p.id === editPlan);
     if (!plan) return;
-    const { error } = await (supabase as any)
-      .from("subscriptions")
-      .update({
-        plan_id: plan.id,
-        monthly_amount: plan.monthly_price,
-        status: "active",
-        next_billing_at: new Date(Date.now() + 30 * 24 * 3600 * 1000).toISOString(),
-      })
-      .eq("id", editTarget.subscription.id);
+    const { error } = editTarget.subscription.inferred
+      ? await (supabase as any)
+          .from("subscriptions")
+          .insert({
+            establishment_id: editTarget.id,
+            plan_id: plan.id,
+            monthly_amount: plan.monthly_price,
+            status: "trial",
+            trial_ends_at: new Date(Date.now() + 10 * 24 * 3600 * 1000).toISOString(),
+            next_billing_at: null,
+          })
+      : await (supabase as any)
+          .from("subscriptions")
+          .update({
+            plan_id: plan.id,
+            monthly_amount: plan.monthly_price,
+            status: "active",
+            next_billing_at: new Date(Date.now() + 30 * 24 * 3600 * 1000).toISOString(),
+          })
+          .eq("id", editTarget.subscription.id);
     if (error) {
       toast.error("Não foi possível alterar o plano.");
       return;
@@ -198,6 +246,7 @@ export default function AdminCompanies() {
     await logAdminAction(user!.id, "change_plan", editTarget.id, {
       new_plan: plan.name,
       monthly: plan.monthly_price,
+      created_subscription: Boolean(editTarget.subscription.inferred),
     });
     toast.success(`Plano alterado para ${plan.name}`);
     setEditTarget(null);
@@ -291,7 +340,7 @@ export default function AdminCompanies() {
                           >
                             <RefreshCw className="h-3.5 w-3.5" /> Plano
                           </Button>
-                          <Button size="sm" variant="ghost" onClick={() => openBilling(r)} disabled={!r.subscription}>
+                          <Button size="sm" variant="ghost" onClick={() => openBilling(r)} disabled={!r.subscription || r.subscription.inferred}>
                             <Wallet className="h-3.5 w-3.5" /> Cobrança
                           </Button>
                           {status === "blocked" ? (

--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -1,60 +1,105 @@
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Building2, TrendingUp, TrendingDown, DollarSign, Users, AlertTriangle, Sparkles } from "lucide-react";
+import { Building2, TrendingUp, TrendingDown, DollarSign, Users, AlertTriangle, Sparkles, Target } from "lucide-react";
 import { fmtBRL } from "./shared";
 import { LineChart, Line, ResponsiveContainer, XAxis, YAxis, Tooltip, BarChart, Bar, CartesianGrid } from "recharts";
 
-type Sub = { status: string; monthly_amount: number; started_at: string; canceled_at: string | null };
-type Profile = { id: string; created_at: string };
+type Sub = {
+  establishment_id: string;
+  status: string;
+  monthly_amount: number;
+  started_at: string;
+  canceled_at: string | null;
+  plan_id: string | null;
+  plan?: { monthly_price: number } | null;
+};
+type Profile = { id: string; created_at: string; selected_plan_slug?: string | null };
+type Plan = { id: string; slug: string; monthly_price: number };
 
 export default function AdminDashboard() {
-  const subs = useQuery({
-    queryKey: ["admin-subs"],
+  const metrics = useQuery({
+    queryKey: ["admin-metrics-with-potential"],
     queryFn: async () => {
-      const { data, error } = await (supabase as any)
-        .from("subscriptions")
-        .select("status, monthly_amount, started_at, canceled_at");
-      if (error) throw error;
-      return (data ?? []) as Sub[];
+      const [{ data: subs, error: subsError }, { data: profiles, error: profilesError }, { data: plans, error: plansError }] = await Promise.all([
+        (supabase as any)
+          .from("subscriptions")
+          .select("establishment_id, status, monthly_amount, started_at, canceled_at, plan_id, subscription_plans(monthly_price)"),
+        (supabase as any).from("profiles").select("id, created_at, selected_plan_slug"),
+        (supabase as any).from("subscription_plans").select("id, slug, monthly_price"),
+      ]);
+      if (subsError) throw subsError;
+      if (profilesError) throw profilesError;
+      if (plansError) throw plansError;
+
+      const plansBySlug = new Map<string, Plan>();
+      (plans ?? []).forEach((p: Plan) => plansBySlug.set(p.slug, p));
+      const subsByEstablishment = new Map<string, Sub>();
+      (subs ?? []).forEach((s: any) => {
+        subsByEstablishment.set(s.establishment_id, {
+          establishment_id: s.establishment_id,
+          status: s.status,
+          monthly_amount: Number(s.monthly_amount || s.subscription_plans?.monthly_price || 0),
+          started_at: s.started_at,
+          canceled_at: s.canceled_at,
+          plan_id: s.plan_id,
+          plan: s.subscription_plans,
+        });
+      });
+
+      const list = (profiles ?? []).map((p: Profile) => {
+        const sub = subsByEstablishment.get(p.id);
+        if (sub) return sub;
+        const chosenPlan = p.selected_plan_slug ? plansBySlug.get(p.selected_plan_slug) : undefined;
+        return {
+          establishment_id: p.id,
+          status: "trial",
+          monthly_amount: Number(chosenPlan?.monthly_price || 0),
+          started_at: p.created_at,
+          canceled_at: null,
+          plan_id: chosenPlan?.id ?? null,
+          plan: chosenPlan ? { monthly_price: chosenPlan.monthly_price } : null,
+        } satisfies Sub;
+      });
+
+      return { list, profiles: (profiles ?? []) as Profile[] };
     },
   });
 
-  const profiles = useQuery({
-    queryKey: ["admin-profiles-min"],
-    queryFn: async () => {
-      const { data, error } = await supabase.from("profiles").select("id, created_at");
-      if (error) throw error;
-      return (data ?? []) as Profile[];
-    },
-  });
-
-  const list = subs.data ?? [];
+  const list = metrics.data?.list ?? [];
+  const profiles = metrics.data?.profiles ?? [];
   const active = list.filter((s) => s.status === "active");
   const trial = list.filter((s) => s.status === "trial");
   const canceled = list.filter((s) => s.status === "canceled");
+  const billablePotential = list.filter((s) => !["canceled", "blocked"].includes(s.status));
   const mrr = active.reduce((sum, s) => sum + Number(s.monthly_amount || 0), 0);
+  const potentialMrr = billablePotential.reduce((sum, s) => sum + Number(s.monthly_amount || s.plan?.monthly_price || 0), 0);
   const arr = mrr * 12;
   const arpu = active.length > 0 ? mrr / active.length : 0;
-  const totalCompanies = profiles.data?.length ?? 0;
+  const totalCompanies = profiles.length;
 
   // MRR evolution last 6 months
   const mrrEvolution = (() => {
-    const months: { label: string; mrr: number; date: Date }[] = [];
+    const months: { label: string; mrr: number; potential: number; date: Date }[] = [];
     const now = new Date();
     for (let i = 5; i >= 0; i--) {
       const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
       const end = new Date(now.getFullYear(), now.getMonth() - i + 1, 1);
-      const monthMrr = list
-        .filter((s) => {
-          const started = new Date(s.started_at);
-          const canceledAt = s.canceled_at ? new Date(s.canceled_at) : null;
-          return s.status === "active" && started < end && (!canceledAt || canceledAt >= d);
-        })
+      const eligible = list.filter((s) => {
+        const started = new Date(s.started_at);
+        const canceledAt = s.canceled_at ? new Date(s.canceled_at) : null;
+        return started < end && (!canceledAt || canceledAt >= d);
+      });
+      const monthMrr = eligible
+        .filter((s) => s.status === "active")
         .reduce((sum, s) => sum + Number(s.monthly_amount || 0), 0);
+      const monthPotential = eligible
+        .filter((s) => !["canceled", "blocked"].includes(s.status))
+        .reduce((sum, s) => sum + Number(s.monthly_amount || s.plan?.monthly_price || 0), 0);
       months.push({
         label: d.toLocaleDateString("pt-BR", { month: "short" }),
         mrr: monthMrr,
+        potential: monthPotential,
         date: d,
       });
     }
@@ -68,7 +113,7 @@ export default function AdminDashboard() {
     for (let i = 5; i >= 0; i--) {
       const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
       const end = new Date(now.getFullYear(), now.getMonth() - i + 1, 1);
-      const novas = (profiles.data ?? []).filter((p) => {
+      const novas = profiles.filter((p) => {
         const c = new Date(p.created_at);
         return c >= d && c < end;
       }).length;
@@ -95,6 +140,7 @@ export default function AdminDashboard() {
 
   const kpis = [
     { label: "MRR", value: fmtBRL(mrr), icon: DollarSign, tone: "text-accent" },
+    { label: "Potencial de faturamento", value: fmtBRL(potentialMrr), icon: Target, tone: "text-success" },
     { label: "ARR", value: fmtBRL(arr), icon: TrendingUp, tone: "text-primary-glow" },
     { label: "Ticket médio (ARPU)", value: fmtBRL(arpu), icon: TrendingUp, tone: "text-accent" },
     { label: "Empresas ativas", value: active.length, icon: Building2, tone: "text-success" },
@@ -163,7 +209,8 @@ export default function AdminDashboard() {
                   contentStyle={{ background: "hsl(var(--card))", border: "1px solid hsl(var(--border))", borderRadius: 8 }}
                   formatter={(v: number) => fmtBRL(v)}
                 />
-                <Line type="monotone" dataKey="mrr" stroke="hsl(var(--primary))" strokeWidth={3} dot={{ fill: "hsl(var(--accent))", r: 4 }} />
+                <Line type="monotone" dataKey="mrr" name="MRR" stroke="hsl(var(--primary))" strokeWidth={3} dot={{ fill: "hsl(var(--accent))", r: 4 }} />
+                <Line type="monotone" dataKey="potential" name="Potencial" stroke="hsl(var(--success))" strokeWidth={2} strokeDasharray="5 5" dot={false} />
               </LineChart>
             </ResponsiveContainer>
           </CardContent>

--- a/src/components/admin/AdminSubscriptions.tsx
+++ b/src/components/admin/AdminSubscriptions.tsx
@@ -5,6 +5,8 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { fmtBRL, fmtDate, STATUS_LABEL, STATUS_TONE } from "./shared";
 import { AlertTriangle, Clock, Sparkles } from "lucide-react";
 
+type Plan = { id: string; name: string; slug: string; monthly_price: number };
+type Profile = { id: string; business_name: string; created_at: string; selected_plan_slug?: string | null };
 type SubRow = {
   id: string;
   establishment_id: string;
@@ -14,36 +16,67 @@ type SubRow = {
   trial_ends_at: string | null;
   next_billing_at: string | null;
   profile?: { business_name: string };
-  plan?: { name: string };
+  plan_id?: string | null;
+  plan?: { name: string; monthly_price?: number };
+  inferred?: boolean;
 };
 
 export default function AdminSubscriptions() {
   const subsQuery = useQuery({
     queryKey: ["admin-subscriptions-full"],
     queryFn: async () => {
-      const { data, error } = await (supabase as any)
+      const [{ data: profiles, error: profilesError }, { data: plans, error: plansError }] = await Promise.all([
+        (supabase as any)
+          .from("profiles")
+          .select("id, business_name, created_at, selected_plan_slug")
+          .order("created_at", { ascending: false }),
+        (supabase as any).from("subscription_plans").select("id, name, slug, monthly_price"),
+      ]);
+      if (profilesError) throw profilesError;
+      if (plansError) throw plansError;
+
+      const plansBySlug = new Map<string, Plan>();
+      (plans ?? []).forEach((p: Plan) => plansBySlug.set(p.slug, p));
+
+      const { data: subs } = await (supabase as any)
         .from("subscriptions")
-        .select("id, establishment_id, status, monthly_amount, started_at, trial_ends_at, next_billing_at, profiles!subscriptions_establishment_id_fkey(business_name), subscription_plans(name)")
+        .select("id, establishment_id, status, monthly_amount, started_at, trial_ends_at, next_billing_at, plan_id, subscription_plans(name, monthly_price)")
         .order("started_at", { ascending: false });
-      // fallback if FK alias not available
-      if (error) {
-        const { data: data2 } = await (supabase as any)
-          .from("subscriptions")
-          .select("id, establishment_id, status, monthly_amount, started_at, trial_ends_at, next_billing_at, subscription_plans(name)");
-        const { data: profs } = await supabase.from("profiles").select("id, business_name");
-        const map = new Map<string, string>();
-        (profs ?? []).forEach((p: any) => map.set(p.id, p.business_name));
-        return (data2 ?? []).map((s: any) => ({
+
+      const subsMap = new Map<string, SubRow>();
+      (subs ?? []).forEach((s: any) => {
+        subsMap.set(s.establishment_id, {
           ...s,
           plan: s.subscription_plans,
-          profile: { business_name: map.get(s.establishment_id) ?? "—" },
-        })) as SubRow[];
-      }
-      return (data ?? []).map((s: any) => ({
-        ...s,
-        plan: s.subscription_plans,
-        profile: s.profiles,
-      })) as SubRow[];
+          profile: undefined,
+        });
+      });
+
+      return (profiles ?? []).map((p: Profile) => {
+        const sub = subsMap.get(p.id);
+        const chosenPlan = p.selected_plan_slug ? plansBySlug.get(p.selected_plan_slug) : undefined;
+        if (sub) {
+          return {
+            ...sub,
+            profile: { business_name: p.business_name },
+            plan: sub.plan ?? (chosenPlan ? { name: chosenPlan.name, monthly_price: chosenPlan.monthly_price } : undefined),
+            monthly_amount: Number(sub.monthly_amount || chosenPlan?.monthly_price || 0),
+          };
+        }
+        return {
+          id: `profile-${p.id}`,
+          establishment_id: p.id,
+          status: "trial",
+          monthly_amount: Number(chosenPlan?.monthly_price || 0),
+          started_at: p.created_at,
+          trial_ends_at: null,
+          next_billing_at: null,
+          profile: { business_name: p.business_name },
+          plan_id: chosenPlan?.id ?? null,
+          plan: chosenPlan ? { name: chosenPlan.name, monthly_price: chosenPlan.monthly_price } : undefined,
+          inferred: true,
+        } satisfies SubRow;
+      }) as SubRow[];
     },
   });
 
@@ -111,8 +144,11 @@ export default function AdminSubscriptions() {
                 {all.map((s) => (
                   <TableRow key={s.id}>
                     <TableCell className="font-medium">{s.profile?.business_name ?? "—"}</TableCell>
-                    <TableCell>{s.plan?.name ?? <span className="text-muted-foreground">Sem plano</span>}</TableCell>
-                    <TableCell>{fmtBRL(Number(s.monthly_amount || 0))}</TableCell>
+                    <TableCell>
+                      {s.plan?.name ?? <span className="text-muted-foreground">Sem plano</span>}
+                      {s.inferred && <div className="text-xs text-muted-foreground">Trial gerado pelo cadastro</div>}
+                    </TableCell>
+                    <TableCell>{fmtBRL(Number(s.monthly_amount || s.plan?.monthly_price || 0))}</TableCell>
                     <TableCell>
                       <span className={`inline-flex px-2 py-0.5 rounded-full text-xs border ${STATUS_TONE[s.status]}`}>
                         {STATUS_LABEL[s.status] ?? s.status}

--- a/src/pages/SelectPlan.tsx
+++ b/src/pages/SelectPlan.tsx
@@ -40,12 +40,18 @@ export default function SelectPlan() {
   async function selectPlan(plan: Plan) {
     if (!profile?.id) return;
     setSaving(plan.id);
-    const { error } = await (supabase as any)
-      .from("subscriptions")
-      .update({ plan_id: plan.id, monthly_amount: plan.monthly_price })
-      .eq("establishment_id", profile.id);
+    const [{ error }, { error: profileError }] = await Promise.all([
+      (supabase as any)
+        .from("subscriptions")
+        .update({ plan_id: plan.id, monthly_amount: plan.monthly_price })
+        .eq("establishment_id", profile.id),
+      (supabase as any)
+        .from("profiles")
+        .update({ selected_plan_slug: plan.slug })
+        .eq("id", profile.id),
+    ]);
     setSaving(null);
-    if (error) {
+    if (error || profileError) {
       toast.error("Não foi possível selecionar o plano");
       return;
     }

--- a/supabase/migrations/20260529000000_store_signup_plan_in_subscriptions.sql
+++ b/supabase/migrations/20260529000000_store_signup_plan_in_subscriptions.sql
@@ -1,0 +1,110 @@
+-- Store the plan selected during signup and create trial subscriptions with that plan.
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS selected_plan_slug text;
+
+-- Backfill the selected plan from auth metadata for companies created before this migration.
+UPDATE public.profiles p
+SET selected_plan_slug = NULLIF(u.raw_user_meta_data ->> 'selected_plan', '')
+FROM auth.users u
+WHERE p.user_id = u.id
+  AND p.selected_plan_slug IS NULL
+  AND NULLIF(u.raw_user_meta_data ->> 'selected_plan', '') IS NOT NULL;
+
+-- Keep only slugs that exist in the current plan catalog.
+UPDATE public.profiles p
+SET selected_plan_slug = NULL
+WHERE selected_plan_slug IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM public.subscription_plans sp WHERE sp.slug = p.selected_plan_slug
+  );
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+BEGIN
+  -- Se o usuário foi criado como staff de um salão existente, NÃO criar novo salão/role de establishment.
+  IF coalesce((new.raw_user_meta_data ->> 'is_staff')::boolean, false) = true THEN
+    RETURN new;
+  END IF;
+
+  INSERT INTO public.profiles (
+    user_id, business_name, document, owner_name, phone, email,
+    cep, street, neighborhood, city, business_type, selected_plan_slug
+  )
+  VALUES (
+    new.id,
+    coalesce(new.raw_user_meta_data ->> 'business_name', 'Meu Salão'),
+    coalesce(nullif(new.raw_user_meta_data ->> 'document', ''), 'PENDENTE'),
+    coalesce(new.raw_user_meta_data ->> 'owner_name', new.raw_user_meta_data ->> 'full_name', 'Proprietário'),
+    coalesce(new.raw_user_meta_data ->> 'phone', new.phone, ''),
+    new.email,
+    coalesce(nullif(new.raw_user_meta_data ->> 'cep', ''), 'PENDENTE'),
+    coalesce(nullif(new.raw_user_meta_data ->> 'street', ''), 'PENDENTE'),
+    coalesce(nullif(new.raw_user_meta_data ->> 'neighborhood', ''), 'PENDENTE'),
+    coalesce(nullif(new.raw_user_meta_data ->> 'city', ''), 'PENDENTE'),
+    coalesce(nullif(new.raw_user_meta_data ->> 'business_type', ''), 'Salao de beleza'),
+    nullif(new.raw_user_meta_data ->> 'selected_plan', '')
+  );
+
+  INSERT INTO public.user_roles (user_id, role)
+  VALUES (new.id, 'establishment')
+  ON CONFLICT (user_id, role) DO NOTHING;
+
+  RETURN new;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.create_trial_subscription()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  selected_plan public.subscription_plans%ROWTYPE;
+BEGIN
+  SELECT sp.* INTO selected_plan
+  FROM public.subscription_plans sp
+  WHERE sp.slug = NEW.selected_plan_slug
+    AND sp.active = true
+  LIMIT 1;
+
+  INSERT INTO public.subscriptions (establishment_id, plan_id, status, trial_ends_at, monthly_amount)
+  VALUES (
+    NEW.id,
+    selected_plan.id,
+    'trial',
+    now() + interval '10 days',
+    coalesce(selected_plan.monthly_price, 0)
+  )
+  ON CONFLICT (establishment_id) DO UPDATE SET
+    plan_id = coalesce(public.subscriptions.plan_id, EXCLUDED.plan_id),
+    monthly_amount = CASE
+      WHEN public.subscriptions.monthly_amount = 0 THEN EXCLUDED.monthly_amount
+      ELSE public.subscriptions.monthly_amount
+    END,
+    updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+-- Backfill subscriptions missing a plan/amount from the selected signup plan.
+UPDATE public.subscriptions s
+SET
+  plan_id = coalesce(s.plan_id, sp.id),
+  monthly_amount = CASE WHEN s.monthly_amount = 0 THEN sp.monthly_price ELSE s.monthly_amount END,
+  updated_at = now()
+FROM public.profiles p
+JOIN public.subscription_plans sp ON sp.slug = p.selected_plan_slug
+WHERE s.establishment_id = p.id
+  AND (s.plan_id IS NULL OR s.monthly_amount = 0);
+
+-- Ensure every company has at least a trial subscription, even if an older trigger failed.
+INSERT INTO public.subscriptions (establishment_id, plan_id, status, trial_ends_at, monthly_amount)
+SELECT p.id, sp.id, 'trial', now() + interval '10 days', coalesce(sp.monthly_price, 0)
+FROM public.profiles p
+LEFT JOIN public.subscription_plans sp ON sp.slug = p.selected_plan_slug
+ON CONFLICT (establishment_id) DO NOTHING;


### PR DESCRIPTION
### Motivation
- Corrigir a ausência do plano/valor das empresas no painel Super Admin exibindo também lojas que só têm cadastro (sem linha em `subscriptions`).
- Mostrar trials inferidos e indicar quando um trial foi criado apenas pelo cadastro. 
- Calcular e expor o potencial de faturamento com base nas lojas cadastradas e no plano escolhido no signup.

### Description
- Adiciona migration `supabase/migrations/20260529000000_store_signup_plan_in_subscriptions.sql` que cria a coluna `selected_plan_slug` em `profiles`, popula-a a partir do metadata de signup e garante trial/subscription seeded com `plan_id` e `monthly_amount` quando aplicável.
- Atualiza `src/components/admin/AdminSubscriptions.tsx` para buscar `profiles`, `subscription_plans` e `subscriptions` em conjunto, inferir trials para perfis sem `subscriptions` e exibir o plano/valor inferido (marca esses registros com `inferred`).
- Atualiza `src/components/admin/AdminCompanies.tsx` para considerar `selected_plan_slug` ao montar a lista de empresas, impedir operações de cobrança/alteração de status em assinaturas inferidas e permitir criar uma `subscription` real ao confirmar alteração de plano de uma empresa inferida.
- Atualiza `src/components/admin/AdminDashboard.tsx` para agregar métricas incluindo o KPI `Potencial de faturamento` calculado a partir de empresas cadastradas (não canceladas) e seus planos/valores escolhidos, e desenhar a série de "potencial" junto ao MRR.
- Persiste o `selected_plan_slug` quando o proprietário escolhe um plano em `src/pages/SelectPlan.tsx` (atualiza `profiles` simultaneamente à atualização de `subscriptions`).

### Testing
- Executado `git diff --check` que não retornou problemas (passou).
- Tentativa de `npm run build` falhou por ambiente local: `vite` não encontrado e dependências não instaladas (build não executado).
- Tentativa de `npm install` travou com erro do registry (`403 Forbidden` ao baixar `@supabase/supabase-js`), então instalação de dependências e build foram bloqueadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19c774b8e4832fb31a5a8fe87bde37)