### PR TITLE
Centralize Super Admin overview, add AdminMetrics and signup-plan/trial migrations

### DIFF
--- a/src/components/admin/AdminCompanies.tsx
+++ b/src/components/admin/AdminCompanies.tsx
@@ -12,6 +12,7 @@ import { Label } from "@/components/ui/label";
 import { toast } from "sonner";
 import { useAuth } from "@/hooks/useAuth";
 import { fmtBRL, fmtDate, STATUS_LABEL, STATUS_TONE, logAdminAction } from "./shared";
+import { fetchAdminOverview } from "./data";
 
 
 type Row = {
@@ -51,42 +52,31 @@ export default function AdminCompanies() {
   const profilesQuery = useQuery({
     queryKey: ["admin-companies"],
     queryFn: async () => {
-      const { data: profiles, error } = await supabase
-        .from("profiles")
-        .select("id, business_name, owner_name, email, phone, created_at, last_access_at")
-        .order("created_at", { ascending: false });
-      if (error) throw error;
-
-      const { data: subs } = await (supabase as any)
-        .from("subscriptions")
-        .select("id, establishment_id, status, plan_id, monthly_amount, next_billing_at, asaas_subscription_id, subscription_plans(name)");
+      const overview = await fetchAdminOverview();
       const subsMap = new Map<string, any>();
-      (subs ?? []).forEach((s: any) => {
+      overview.subscriptions.forEach((s) => {
         subsMap.set(s.establishment_id, {
           id: s.id,
           status: s.status,
           plan_id: s.plan_id,
-          monthly_amount: Number(s.monthly_amount || 0),
+          monthly_amount: Number(s.monthly_amount || s.plan?.monthly_price || 0),
           next_billing_at: s.next_billing_at,
           asaas_subscription_id: s.asaas_subscription_id,
-          plan: s.subscription_plans ? { name: s.subscription_plans.name } : undefined,
+          plan: s.plan ? { name: s.plan.name } : undefined,
         });
       });
 
-      return (profiles ?? []).map((p: any) => ({ ...p, subscription: subsMap.get(p.id) })) as Row[];
+      return overview.profiles.map((p: any) => ({ ...p, subscription: subsMap.get(p.id) })) as Row[];
     },
   });
 
   const plansQuery = useQuery({
     queryKey: ["admin-plans"],
     queryFn: async () => {
-      const { data, error } = await (supabase as any)
-        .from("subscription_plans")
-        .select("id, name, monthly_price")
-        .eq("active", true)
-        .order("display_order");
-      if (error) throw error;
-      return data as { id: string; name: string; monthly_price: number }[];
+      const overview = await fetchAdminOverview();
+      return overview.plans
+        .filter((p) => p.active)
+        .map((p) => ({ id: p.id, name: p.name, monthly_price: p.monthly_price }));
     },
   });
 

--- a/src/components/admin/AdminControl.tsx
+++ b/src/components/admin/AdminControl.tsx
@@ -3,6 +3,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { ShieldAlert } from "lucide-react";
+import { fetchAdminOverview } from "./data";
 
 type LogRow = {
   id: string;
@@ -33,9 +34,9 @@ export default function AdminControl() {
         .order("created_at", { ascending: false })
         .limit(100);
       if (error) throw error;
-      const { data: profs } = await supabase.from("profiles").select("id, business_name");
+      const overview = await fetchAdminOverview();
       const map = new Map<string, string>();
-      (profs ?? []).forEach((p: any) => map.set(p.id, p.business_name));
+      overview.profiles.forEach((p) => map.set(p.id, p.business_name));
       return (data ?? []).map((l: any) => ({
         ...l,
         target_name: l.target_establishment_id ? map.get(l.target_establishment_id) ?? "—" : "—",

--- a/src/components/admin/AdminMetrics.tsx
+++ b/src/components/admin/AdminMetrics.tsx
@@ -1,59 +1,69 @@
 import { useQuery } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Building2, TrendingUp, TrendingDown, DollarSign, Users, AlertTriangle, Sparkles } from "lucide-react";
+import { AlertTriangle, Building2, DollarSign, Sparkles, Target, TrendingDown, TrendingUp, Users } from "lucide-react";
+import { Bar, BarChart, CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { fmtBRL } from "./shared";
-import { LineChart, Line, ResponsiveContainer, XAxis, YAxis, Tooltip, BarChart, Bar, CartesianGrid } from "recharts";
 import { fetchAdminOverview } from "./data";
 
-type Sub = { status: string; monthly_amount: number; started_at: string; canceled_at: string | null; plan?: { monthly_price: number } | null };
+type Sub = {
+  status: string;
+  monthly_amount: number;
+  started_at: string;
+  canceled_at: string | null;
+  plan?: { monthly_price: number } | null;
+};
+
 type Profile = { id: string; created_at: string };
 
-export default function AdminDashboard() {
-  const overview = useQuery({
-    queryKey: ["admin-dashboard-overview"],
+export default function AdminMetrics() {
+  const metrics = useQuery({
+    queryKey: ["admin-metrics"],
     queryFn: fetchAdminOverview,
   });
 
-  const list = (overview.data?.subscriptions ?? []).map((s) => ({
+  const list = (metrics.data?.subscriptions ?? []).map((s) => ({
     status: s.status,
     monthly_amount: Number(s.monthly_amount || s.plan?.monthly_price || 0),
     started_at: s.started_at,
     canceled_at: s.canceled_at,
     plan: s.plan,
   })) as Sub[];
+  const profiles = metrics.data?.profiles ?? [];
   const active = list.filter((s) => s.status === "active");
   const trial = list.filter((s) => s.status === "trial");
   const canceled = list.filter((s) => s.status === "canceled");
+  const billablePotential = list.filter((s) => !["canceled", "blocked"].includes(s.status));
   const mrr = active.reduce((sum, s) => sum + Number(s.monthly_amount || 0), 0);
+  const potentialMrr = billablePotential.reduce((sum, s) => sum + Number(s.monthly_amount || s.plan?.monthly_price || 0), 0);
   const arr = mrr * 12;
   const arpu = active.length > 0 ? mrr / active.length : 0;
-  const profiles = (overview.data?.profiles ?? []) as Profile[];
   const totalCompanies = profiles.length;
 
-  // MRR evolution last 6 months
   const mrrEvolution = (() => {
-    const months: { label: string; mrr: number; date: Date }[] = [];
+    const months: { label: string; mrr: number; potential: number; date: Date }[] = [];
     const now = new Date();
     for (let i = 5; i >= 0; i--) {
       const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
       const end = new Date(now.getFullYear(), now.getMonth() - i + 1, 1);
-      const monthMrr = list
-        .filter((s) => {
-          const started = new Date(s.started_at);
-          const canceledAt = s.canceled_at ? new Date(s.canceled_at) : null;
-          return s.status === "active" && started < end && (!canceledAt || canceledAt >= d);
-        })
-        .reduce((sum, s) => sum + Number(s.monthly_amount || 0), 0);
+      const eligible = list.filter((s) => {
+        const started = new Date(s.started_at);
+        const canceledAt = s.canceled_at ? new Date(s.canceled_at) : null;
+        return started < end && (!canceledAt || canceledAt >= d);
+      });
       months.push({
         label: d.toLocaleDateString("pt-BR", { month: "short" }),
-        mrr: monthMrr,
+        mrr: eligible
+          .filter((s) => s.status === "active")
+          .reduce((sum, s) => sum + Number(s.monthly_amount || 0), 0),
+        potential: eligible
+          .filter((s) => !["canceled", "blocked"].includes(s.status))
+          .reduce((sum, s) => sum + Number(s.monthly_amount || s.plan?.monthly_price || 0), 0),
         date: d,
       });
     }
     return months;
   })();
 
-  // New companies per month last 6 months
   const newPerMonth = (() => {
     const months: { label: string; novas: number; cancel: number }[] = [];
     const now = new Date();
@@ -61,20 +71,19 @@ export default function AdminDashboard() {
       const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
       const end = new Date(now.getFullYear(), now.getMonth() - i + 1, 1);
       const novas = profiles.filter((p) => {
-        const c = new Date(p.created_at);
-        return c >= d && c < end;
+        const created = new Date(p.created_at);
+        return created >= d && created < end;
       }).length;
       const cancel = list.filter((s) => {
         if (!s.canceled_at) return false;
-        const c = new Date(s.canceled_at);
-        return c >= d && c < end;
+        const canceledAt = new Date(s.canceled_at);
+        return canceledAt >= d && canceledAt < end;
       }).length;
       months.push({ label: d.toLocaleDateString("pt-BR", { month: "short" }), novas, cancel });
     }
     return months;
   })();
 
-  // Insights
   const currMrr = mrrEvolution[mrrEvolution.length - 1]?.mrr ?? 0;
   const prevMrr = mrrEvolution[mrrEvolution.length - 2]?.mrr ?? 0;
   const mrrDelta = prevMrr > 0 ? ((currMrr - prevMrr) / prevMrr) * 100 : 0;
@@ -87,6 +96,7 @@ export default function AdminDashboard() {
 
   const kpis = [
     { label: "MRR", value: fmtBRL(mrr), icon: DollarSign, tone: "text-accent" },
+    { label: "Potencial de faturamento", value: fmtBRL(potentialMrr), icon: Target, tone: "text-success" },
     { label: "ARR", value: fmtBRL(arr), icon: TrendingUp, tone: "text-primary-glow" },
     { label: "Ticket médio (ARPU)", value: fmtBRL(arpu), icon: TrendingUp, tone: "text-accent" },
     { label: "Empresas ativas", value: active.length, icon: Building2, tone: "text-success" },
@@ -112,7 +122,6 @@ export default function AdminDashboard() {
         ))}
       </div>
 
-      {/* Insights */}
       <div className="grid gap-3 md:grid-cols-3">
         <Card className="bg-card/60 border-border/60">
           <CardContent className="p-4">
@@ -155,7 +164,8 @@ export default function AdminDashboard() {
                   contentStyle={{ background: "hsl(var(--card))", border: "1px solid hsl(var(--border))", borderRadius: 8 }}
                   formatter={(v: number) => fmtBRL(v)}
                 />
-                <Line type="monotone" dataKey="mrr" stroke="hsl(var(--primary))" strokeWidth={3} dot={{ fill: "hsl(var(--accent))", r: 4 }} />
+                <Line type="monotone" dataKey="mrr" name="MRR" stroke="hsl(var(--primary))" strokeWidth={3} dot={{ fill: "hsl(var(--accent))", r: 4 }} />
+                <Line type="monotone" dataKey="potential" name="Potencial" stroke="hsl(var(--success))" strokeWidth={2} strokeDasharray="5 5" dot={false} />
               </LineChart>
             </ResponsiveContainer>
           </CardContent>

--- a/src/components/admin/AdminSaaSFinance.tsx
+++ b/src/components/admin/AdminSaaSFinance.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
-import { supabase } from "@/integrations/supabase/client";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { fmtBRL } from "./shared";
+import { fetchAdminOverview } from "./data";
 import { BarChart, Bar, ResponsiveContainer, XAxis, YAxis, Tooltip, CartesianGrid, PieChart, Pie, Cell, Legend } from "recharts";
 
 const COLORS = ["hsl(var(--primary))", "hsl(var(--accent))", "hsl(var(--primary-glow))", "hsl(var(--success))"];
@@ -10,11 +10,14 @@ export default function AdminSaaSFinance() {
   const subsQuery = useQuery({
     queryKey: ["admin-finance-subs"],
     queryFn: async () => {
-      const { data, error } = await (supabase as any)
-        .from("subscriptions")
-        .select("status, monthly_amount, started_at, plan_id, subscription_plans(name)");
-      if (error) throw error;
-      return (data ?? []) as { status: string; monthly_amount: number; started_at: string; plan_id: string; subscription_plans: { name: string } | null }[];
+      const overview = await fetchAdminOverview();
+      return overview.subscriptions.map((s) => ({
+        status: s.status,
+        monthly_amount: Number(s.monthly_amount || s.plan?.monthly_price || 0),
+        started_at: s.started_at,
+        plan_id: s.plan_id,
+        subscription_plans: s.plan ? { name: s.plan.name } : null,
+      }));
     },
   });
 

--- a/src/components/admin/AdminSubscriptions.tsx
+++ b/src/components/admin/AdminSubscriptions.tsx
@@ -1,9 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
-import { supabase } from "@/integrations/supabase/client";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { fmtBRL, fmtDate, STATUS_LABEL, STATUS_TONE } from "./shared";
 import { AlertTriangle, Clock, Sparkles } from "lucide-react";
+import { fetchAdminOverview } from "./data";
 
 type SubRow = {
   id: string;
@@ -21,28 +21,18 @@ export default function AdminSubscriptions() {
   const subsQuery = useQuery({
     queryKey: ["admin-subscriptions-full"],
     queryFn: async () => {
-      const { data, error } = await (supabase as any)
-        .from("subscriptions")
-        .select("id, establishment_id, status, monthly_amount, started_at, trial_ends_at, next_billing_at, profiles!subscriptions_establishment_id_fkey(business_name), subscription_plans(name)")
-        .order("started_at", { ascending: false });
-      // fallback if FK alias not available
-      if (error) {
-        const { data: data2 } = await (supabase as any)
-          .from("subscriptions")
-          .select("id, establishment_id, status, monthly_amount, started_at, trial_ends_at, next_billing_at, subscription_plans(name)");
-        const { data: profs } = await supabase.from("profiles").select("id, business_name");
-        const map = new Map<string, string>();
-        (profs ?? []).forEach((p: any) => map.set(p.id, p.business_name));
-        return (data2 ?? []).map((s: any) => ({
-          ...s,
-          plan: s.subscription_plans,
-          profile: { business_name: map.get(s.establishment_id) ?? "—" },
-        })) as SubRow[];
-      }
-      return (data ?? []).map((s: any) => ({
-        ...s,
-        plan: s.subscription_plans,
-        profile: s.profiles,
+      const overview = await fetchAdminOverview();
+      const profilesMap = new Map(overview.profiles.map((p) => [p.id, p.business_name]));
+      return overview.subscriptions.map((s) => ({
+        id: s.id,
+        establishment_id: s.establishment_id,
+        status: s.status,
+        monthly_amount: Number(s.monthly_amount || s.plan?.monthly_price || 0),
+        started_at: s.started_at,
+        trial_ends_at: s.trial_ends_at,
+        next_billing_at: s.next_billing_at,
+        plan: s.plan ? { name: s.plan.name } : undefined,
+        profile: { business_name: profilesMap.get(s.establishment_id) ?? "—" },
       })) as SubRow[];
     },
   });

--- a/src/components/admin/data.ts
+++ b/src/components/admin/data.ts
@@ -1,0 +1,99 @@
+import { supabase } from "@/integrations/supabase/client";
+
+export type AdminPlan = {
+  id: string;
+  name: string;
+  slug: string | null;
+  monthly_price: number;
+  active: boolean;
+  display_order: number;
+};
+
+export type AdminProfile = {
+  id: string;
+  business_name: string;
+  owner_name: string | null;
+  email: string | null;
+  phone: string | null;
+  created_at: string;
+  last_access_at: string | null;
+  selected_plan_slug: string | null;
+};
+
+export type AdminSubscription = {
+  id: string;
+  establishment_id: string;
+  status: string;
+  plan_id: string | null;
+  monthly_amount: number;
+  started_at: string;
+  trial_ends_at: string | null;
+  next_billing_at: string | null;
+  canceled_at: string | null;
+  asaas_subscription_id: string | null;
+  plan: { id: string; name: string; slug: string | null; monthly_price: number } | null;
+};
+
+export type AdminOverview = {
+  profiles: AdminProfile[];
+  subscriptions: AdminSubscription[];
+  plans: AdminPlan[];
+};
+
+const normalizeOverview = (value: any): AdminOverview => ({
+  profiles: (value?.profiles ?? []) as AdminProfile[],
+  subscriptions: (value?.subscriptions ?? []).map((s: any) => ({
+    ...s,
+    monthly_amount: Number(s.monthly_amount || s.plan?.monthly_price || 0),
+  })) as AdminSubscription[],
+  plans: (value?.plans ?? []).map((p: any) => ({
+    ...p,
+    monthly_price: Number(p.monthly_price || 0),
+    display_order: Number(p.display_order || 0),
+  })) as AdminPlan[],
+});
+
+async function fetchAdminOverviewFallback(): Promise<AdminOverview> {
+  const profilesWithPlan = await (supabase as any)
+    .from("profiles")
+    .select("id, business_name, owner_name, email, phone, created_at, last_access_at, selected_plan_slug")
+    .order("created_at", { ascending: false });
+  const profilesResult = profilesWithPlan.error
+    ? await (supabase as any)
+        .from("profiles")
+        .select("id, business_name, owner_name, email, phone, created_at, last_access_at")
+        .order("created_at", { ascending: false })
+    : profilesWithPlan;
+
+  const [{ data: subscriptions, error: subscriptionsError }, { data: plans, error: plansError }] = await Promise.all([
+    (supabase as any)
+      .from("subscriptions")
+      .select("id, establishment_id, status, plan_id, monthly_amount, started_at, trial_ends_at, next_billing_at, canceled_at, asaas_subscription_id, subscription_plans(id, name, slug, monthly_price)"),
+    (supabase as any)
+      .from("subscription_plans")
+      .select("id, name, slug, monthly_price, active, display_order")
+      .order("display_order"),
+  ]);
+
+  if (profilesResult.error) throw profilesResult.error;
+  if (subscriptionsError) throw subscriptionsError;
+  if (plansError) throw plansError;
+
+  return normalizeOverview({
+    profiles: (profilesResult.data ?? []).map((profile: any) => ({
+      ...profile,
+      selected_plan_slug: profile.selected_plan_slug ?? null,
+    })),
+    plans,
+    subscriptions: (subscriptions ?? []).map((s: any) => ({
+      ...s,
+      plan: s.subscription_plans,
+    })),
+  });
+}
+
+export async function fetchAdminOverview(): Promise<AdminOverview> {
+  const { data, error } = await (supabase as any).rpc("get_super_admin_overview");
+  if (!error && data) return normalizeOverview(data);
+  return fetchAdminOverviewFallback();
+}

--- a/src/pages/SuperAdmin.tsx
+++ b/src/pages/SuperAdmin.tsx
@@ -19,6 +19,7 @@ import AdminSubscriptions from "@/components/admin/AdminSubscriptions";
 import AdminSaaSFinance from "@/components/admin/AdminSaaSFinance";
 import AdminControl from "@/components/admin/AdminControl";
 import AdminPlans from "@/components/admin/AdminPlans";
+import AdminMetrics from "@/components/admin/AdminMetrics";
 
 type Tab = "dashboard" | "companies" | "subscriptions" | "finance" | "metrics" | "control" | "plans";
 
@@ -121,7 +122,7 @@ export default function SuperAdmin() {
       {tab === "companies" && <AdminCompanies />}
       {tab === "subscriptions" && <AdminSubscriptions />}
       {tab === "finance" && <AdminSaaSFinance />}
-      {tab === "metrics" && <AdminDashboard />}
+      {tab === "metrics" && <AdminMetrics />}
       {tab === "control" && <AdminControl />}
       {tab === "plans" && <AdminPlans />}
     </main>

--- a/supabase/migrations/20260529000000_store_signup_plan_in_subscriptions.sql
+++ b/supabase/migrations/20260529000000_store_signup_plan_in_subscriptions.sql
@@ -1,0 +1,110 @@
+-- Store the plan selected during signup and create trial subscriptions with that plan.
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS selected_plan_slug text;
+
+-- Backfill the selected plan from auth metadata for companies created before this migration.
+UPDATE public.profiles p
+SET selected_plan_slug = NULLIF(u.raw_user_meta_data ->> 'selected_plan', '')
+FROM auth.users u
+WHERE p.user_id = u.id
+  AND p.selected_plan_slug IS NULL
+  AND NULLIF(u.raw_user_meta_data ->> 'selected_plan', '') IS NOT NULL;
+
+-- Keep only slugs that exist in the current plan catalog.
+UPDATE public.profiles p
+SET selected_plan_slug = NULL
+WHERE selected_plan_slug IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM public.subscription_plans sp WHERE sp.slug = p.selected_plan_slug
+  );
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+BEGIN
+  -- Se o usuário foi criado como staff de um salão existente, NÃO criar novo salão/role de establishment.
+  IF coalesce((new.raw_user_meta_data ->> 'is_staff')::boolean, false) = true THEN
+    RETURN new;
+  END IF;
+
+  INSERT INTO public.profiles (
+    user_id, business_name, document, owner_name, phone, email,
+    cep, street, neighborhood, city, business_type, selected_plan_slug
+  )
+  VALUES (
+    new.id,
+    coalesce(new.raw_user_meta_data ->> 'business_name', 'Meu Salão'),
+    coalesce(nullif(new.raw_user_meta_data ->> 'document', ''), 'PENDENTE'),
+    coalesce(new.raw_user_meta_data ->> 'owner_name', new.raw_user_meta_data ->> 'full_name', 'Proprietário'),
+    coalesce(new.raw_user_meta_data ->> 'phone', new.phone, ''),
+    new.email,
+    coalesce(nullif(new.raw_user_meta_data ->> 'cep', ''), 'PENDENTE'),
+    coalesce(nullif(new.raw_user_meta_data ->> 'street', ''), 'PENDENTE'),
+    coalesce(nullif(new.raw_user_meta_data ->> 'neighborhood', ''), 'PENDENTE'),
+    coalesce(nullif(new.raw_user_meta_data ->> 'city', ''), 'PENDENTE'),
+    coalesce(nullif(new.raw_user_meta_data ->> 'business_type', ''), 'Salao de beleza'),
+    nullif(new.raw_user_meta_data ->> 'selected_plan', '')
+  );
+
+  INSERT INTO public.user_roles (user_id, role)
+  VALUES (new.id, 'establishment')
+  ON CONFLICT (user_id, role) DO NOTHING;
+
+  RETURN new;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.create_trial_subscription()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  selected_plan public.subscription_plans%ROWTYPE;
+BEGIN
+  SELECT sp.* INTO selected_plan
+  FROM public.subscription_plans sp
+  WHERE sp.slug = NEW.selected_plan_slug
+    AND sp.active = true
+  LIMIT 1;
+
+  INSERT INTO public.subscriptions (establishment_id, plan_id, status, trial_ends_at, monthly_amount)
+  VALUES (
+    NEW.id,
+    selected_plan.id,
+    'trial',
+    now() + interval '10 days',
+    coalesce(selected_plan.monthly_price, 0)
+  )
+  ON CONFLICT (establishment_id) DO UPDATE SET
+    plan_id = coalesce(public.subscriptions.plan_id, EXCLUDED.plan_id),
+    monthly_amount = CASE
+      WHEN public.subscriptions.monthly_amount = 0 THEN EXCLUDED.monthly_amount
+      ELSE public.subscriptions.monthly_amount
+    END,
+    updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+-- Backfill subscriptions missing a plan/amount from the selected signup plan.
+UPDATE public.subscriptions s
+SET
+  plan_id = coalesce(s.plan_id, sp.id),
+  monthly_amount = CASE WHEN s.monthly_amount = 0 THEN sp.monthly_price ELSE s.monthly_amount END,
+  updated_at = now()
+FROM public.profiles p
+JOIN public.subscription_plans sp ON sp.slug = p.selected_plan_slug
+WHERE s.establishment_id = p.id
+  AND (s.plan_id IS NULL OR s.monthly_amount = 0);
+
+-- Ensure every company has at least a trial subscription, even if an older trigger failed.
+INSERT INTO public.subscriptions (establishment_id, plan_id, status, trial_ends_at, monthly_amount)
+SELECT p.id, sp.id, 'trial', now() + interval '10 days', coalesce(sp.monthly_price, 0)
+FROM public.profiles p
+LEFT JOIN public.subscription_plans sp ON sp.slug = p.selected_plan_slug
+ON CONFLICT (establishment_id) DO NOTHING;

--- a/supabase/migrations/20260529010000_super_admin_overview_rpc.sql
+++ b/supabase/migrations/20260529010000_super_admin_overview_rpc.sql
@@ -1,0 +1,87 @@
+-- Centralized Super Admin data source. Uses SECURITY DEFINER so the admin panel
+-- does not render empty when table RLS policies hide tenant data from direct selects.
+CREATE OR REPLACE FUNCTION public.get_super_admin_overview()
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  is_admin boolean;
+  result jsonb;
+BEGIN
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.user_roles ur
+    WHERE ur.user_id = auth.uid()
+      AND ur.role::text = 'super_admin'
+  ) INTO is_admin;
+
+  IF NOT is_admin THEN
+    RAISE EXCEPTION 'Acesso restrito ao Super Admin.' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT jsonb_build_object(
+    'profiles', COALESCE((
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'id', p.id,
+          'business_name', p.business_name,
+          'owner_name', p.owner_name,
+          'email', p.email,
+          'phone', p.phone,
+          'created_at', p.created_at,
+          'last_access_at', p.last_access_at,
+          'selected_plan_slug', p.selected_plan_slug
+        )
+        ORDER BY p.created_at DESC
+      )
+      FROM public.profiles p
+    ), '[]'::jsonb),
+    'subscriptions', COALESCE((
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'id', s.id,
+          'establishment_id', s.establishment_id,
+          'status', s.status,
+          'plan_id', s.plan_id,
+          'monthly_amount', s.monthly_amount,
+          'started_at', s.started_at,
+          'trial_ends_at', s.trial_ends_at,
+          'next_billing_at', s.next_billing_at,
+          'canceled_at', s.canceled_at,
+          'asaas_subscription_id', s.asaas_subscription_id,
+          'plan', CASE WHEN sp.id IS NULL THEN NULL ELSE jsonb_build_object(
+            'id', sp.id,
+            'name', sp.name,
+            'slug', sp.slug,
+            'monthly_price', sp.monthly_price
+          ) END
+        )
+        ORDER BY s.started_at DESC
+      )
+      FROM public.subscriptions s
+      LEFT JOIN public.subscription_plans sp ON sp.id = s.plan_id
+    ), '[]'::jsonb),
+    'plans', COALESCE((
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'id', sp.id,
+          'name', sp.name,
+          'slug', sp.slug,
+          'monthly_price', sp.monthly_price,
+          'active', sp.active,
+          'display_order', sp.display_order
+        )
+        ORDER BY sp.display_order ASC, sp.name ASC
+      )
+      FROM public.subscription_plans sp
+    ), '[]'::jsonb)
+  ) INTO result;
+
+  RETURN result;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_super_admin_overview() TO authenticated;


### PR DESCRIPTION
### Motivation

- Provide a single, secure data source for the Super Admin UI to avoid RLS visibility issues and reduce duplicated queries.
- Ensure the plan selected during signup is stored and used to create trial subscriptions with the correct plan/amount.
- Improve admin reporting by adding a dedicated metrics panel that reuses the centralized overview.

### Description

- Added `src/components/admin/data.ts` with `fetchAdminOverview()` that calls the `get_super_admin_overview()` RPC and falls back to direct selects when necessary, normalizing profiles, subscriptions and plans.
- Replaced many ad-hoc Supabase selects across admin components (`AdminCompanies`, `AdminControl`, `AdminDashboard`, `AdminSaaSFinance`, `AdminSubscriptions`) to use `fetchAdminOverview()` and unified subscription `monthly_amount` fallback to the plan price when missing.
- Introduced a new `AdminMetrics` UI component and wired it into `SuperAdmin.tsx` as the `metrics` tab to surface KPI cards, MRR evolution and new vs canceled company charts.
- Added two Supabase migration SQL files: one to store `selected_plan_slug` in `profiles`, create trial subscriptions on signup and backfill subscriptions, and another to create the `get_super_admin_overview()` RPC (with `SECURITY DEFINER`) and grant execute to `authenticated` users.

### Testing

- Ran the project typecheck/build via `pnpm build` and it completed successfully.
- Executed the test suite via `pnpm test` and all tests passed.
- Verified the admin pages compile and the new `metrics` tab renders without runtime TypeScript errors in a local dev build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19c774b8e4832fb31a5a8fe87bde37)