### PR TITLE
Corrige seleção de cliente para bases com muitos cadastros

### DIFF
--- a/src/components/ClientCombobox.tsx
+++ b/src/components/ClientCombobox.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { Input } from "@/components/ui/input";
@@ -10,6 +10,40 @@ import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 
 interface ClientLite { id: string; name: string; phone?: string | null }
+
+const CLIENTS_PAGE_SIZE = 1000;
+const INITIAL_VISIBLE_CLIENTS = 50;
+const VISIBLE_CLIENTS_INCREMENT = 50;
+
+async function fetchAllClients(establishmentId: string) {
+  const allClients: ClientLite[] = [];
+  let from = 0;
+
+  while (true) {
+    const to = from + CLIENTS_PAGE_SIZE - 1;
+    const { data, error } = await supabase
+      .from("clients")
+      .select("id, name, phone")
+      .eq("establishment_id", establishmentId)
+      .order("name")
+      .range(from, to);
+
+    if (error) {
+      throw error;
+    }
+
+    const page = (data ?? []) as ClientLite[];
+    allClients.push(...page);
+
+    if (page.length < CLIENTS_PAGE_SIZE) {
+      break;
+    }
+
+    from += CLIENTS_PAGE_SIZE;
+  }
+
+  return allClients;
+}
 
 interface Props {
   establishmentId: string;
@@ -26,19 +60,17 @@ export function ClientCombobox({ establishmentId, value, onChange, compact = tru
   const [openCreate, setOpenCreate] = useState(false);
   const [form, setForm] = useState({ name: "", phone: "", acquisition_source: "" });
   const [saving, setSaving] = useState(false);
+  const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE_CLIENTS);
 
-  const { data: clients } = useQuery<ClientLite[]>({
+  const { data: clients, isLoading, isError } = useQuery<ClientLite[]>({
     queryKey: ["clients-combobox", establishmentId],
     enabled: !!establishmentId,
-    queryFn: async () => {
-      const { data } = await supabase
-        .from("clients")
-        .select("id, name, phone")
-        .eq("establishment_id", establishmentId)
-        .order("name");
-      return (data ?? []) as ClientLite[];
-    },
+    queryFn: () => fetchAllClients(establishmentId),
   });
+
+  useEffect(() => {
+    setVisibleCount(INITIAL_VISIBLE_CLIENTS);
+  }, [search, establishmentId]);
 
   const selected = clients?.find(c => c.id === value);
 
@@ -49,6 +81,13 @@ export function ClientCombobox({ establishmentId, value, onChange, compact = tru
       c.name.toLowerCase().includes(q) || (c.phone ?? "").toLowerCase().includes(q)
     );
   }, [clients, search]);
+
+  const visibleClients = useMemo(
+    () => filtered.slice(0, visibleCount),
+    [filtered, visibleCount]
+  );
+
+  const hasMoreClients = filtered.length > visibleClients.length;
 
   const openWithSearch = () => {
     setForm(f => ({ ...f, name: /^[a-zA-ZÀ-ÿ\s]+$/.test(search) ? search : f.name, phone: /^[\d\s()+\-]+$/.test(search) ? search : f.phone }));
@@ -108,7 +147,17 @@ export function ClientCombobox({ establishmentId, value, onChange, compact = tru
       </div>
 
       <div className="max-h-48 overflow-y-auto rounded-md border bg-background">
-        {filtered.slice(0, 8).map(c => (
+        {isLoading && (
+          <div className="px-3 py-3 text-sm text-muted-foreground text-center">
+            Carregando clientes...
+          </div>
+        )}
+        {isError && (
+          <div className="px-3 py-3 text-sm text-destructive text-center">
+            Erro ao carregar clientes.
+          </div>
+        )}
+        {!isLoading && !isError && visibleClients.map(c => (
           <button
             key={c.id}
             type="button"
@@ -119,10 +168,20 @@ export function ClientCombobox({ establishmentId, value, onChange, compact = tru
             {c.phone && <span className="text-xs text-muted-foreground">{c.phone}</span>}
           </button>
         ))}
-        {filtered.length === 0 && (
+        {!isLoading && !isError && filtered.length === 0 && (
           <div className="px-3 py-3 text-sm text-muted-foreground text-center">
             {search ? "Nenhum cliente encontrado." : "Digite para buscar..."}
           </div>
+        )}
+        {!isLoading && !isError && hasMoreClients && (
+          <Button
+            type="button"
+            variant="ghost"
+            className="w-full rounded-none text-xs text-muted-foreground"
+            onClick={() => setVisibleCount(count => count + VISIBLE_CLIENTS_INCREMENT)}
+          >
+            Mostrar mais {Math.min(VISIBLE_CLIENTS_INCREMENT, filtered.length - visibleClients.length)} de {filtered.length} clientes
+          </Button>
         )}
       </div>
 


### PR DESCRIPTION
### Motivation
- O combobox de cliente usado ao criar/editar agendamentos não exibia toda a lista quando a base tinha muitos clientes devido aos limites de página do Supabase, causando falta de opções e problemas na seleção.

### Description
- Substituí a consulta única por uma função `fetchAllClients` que pagina explicitamente em blocos de `CLIENTS_PAGE_SIZE` (1.000) para carregar todos os clientes do estabelecimento em lotes.
- Troquei o bloco de renderização fixo `filtered.slice(0, 8)` por uma lista incremental controlada por `visibleCount` com `INITIAL_VISIBLE_CLIENTS = 50` e botão "Mostrar mais" que aumenta `VISIBLE_CLIENTS_INCREMENT = 50` para manter a interface responsiva.
- Adicionei estados de carregamento e erro (`isLoading` / `isError`) à lista do combobox e reseto de `visibleCount` ao alterar a busca ou o `establishmentId`.
- Arquivo alterado: `src/components/ClientCombobox.tsx` (adição de paginação, controle de visibilidade e UI de feedback).

### Testing
- `git diff --check` foi executado com sucesso para verificar o diff do arquivo modificado.
- `npm run lint` foi executado porém foi bloqueado por dependências locais ausentes/irresolvíveis (`@eslint/js`), portanto não concluiu com sucesso.
- `npm run build` foi executado porém não concluiu porque `vite`/dependências não estavam instaladas no ambiente de execução.
- `npm ci --prefer-offline --no-audit --no-fund` foi tentado porém falhou devido a divergências entre `package.json` e `package-lock.json`, impedindo instalação limpa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d8f927cc0832f9ab50c0eca209d00)