### PR TITLE
Add theme support and toggle; enhance agenda filtering, calendar controls, and client combobox; add DB index

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "@/hooks/useAuth";
+import { ThemeProvider } from "@/components/ThemeProvider";
 import Index from "./pages/Index";
 import Auth from "./pages/Auth";
 import Dashboard from "./pages/Dashboard";
@@ -30,42 +31,44 @@ const queryClient = new QueryClient();
 
 const App = () => (
   <QueryClientProvider client={queryClient}>
-    <TooltipProvider>
-      <AuthProvider>
-        <Toaster />
-        <Sonner />
-        <BrowserRouter>
-          <Routes>
-            <Route path="/auth" element={<Auth />} />
-            <Route path="/" element={<Index />} />
-            <Route path="/agendar/:establishmentId" element={<PublicBooking />} />
-            <Route path="/:slug" element={<PublicBooking />} />
-            <Route element={<AppLayout />}>
-              <Route path="/dashboard" element={<Dashboard />} />
-              <Route path="/clients" element={<Clients />} />
-              <Route path="/services" element={<Services />} />
-              <Route path="/products" element={<Products />} />
-              <Route path="/sales" element={<Sales />} />
-              <Route path="/expenses" element={<Expenses />} />
-              <Route path="/agenda" element={<Agenda />} />
-              <Route path="/atendimentos" element={<Attendances />} />
-              <Route path="/reports" element={<Reports />} />
-              <Route path="/metrics" element={<Metrics />} />
-              <Route path="/settings" element={<Settings />} />
-              <Route path="/users" element={<Users />} />
-              <Route path="/escolher-plano" element={<SelectPlan />} />
-              <Route path="/checkout" element={<Checkout />} />
-              <Route path="/planos" element={<Plans />} />
-              <Route path="/admin" element={<SuperAdmin />} />
+    <ThemeProvider>
+      <TooltipProvider>
+        <AuthProvider>
+          <Toaster />
+          <Sonner />
+          <BrowserRouter>
+            <Routes>
+              <Route path="/auth" element={<Auth />} />
+              <Route path="/" element={<Index />} />
+              <Route path="/agendar/:establishmentId" element={<PublicBooking />} />
+              <Route path="/:slug" element={<PublicBooking />} />
+              <Route element={<AppLayout />}>
+                <Route path="/dashboard" element={<Dashboard />} />
+                <Route path="/clients" element={<Clients />} />
+                <Route path="/services" element={<Services />} />
+                <Route path="/products" element={<Products />} />
+                <Route path="/sales" element={<Sales />} />
+                <Route path="/expenses" element={<Expenses />} />
+                <Route path="/agenda" element={<Agenda />} />
+                <Route path="/atendimentos" element={<Attendances />} />
+                <Route path="/reports" element={<Reports />} />
+                <Route path="/metrics" element={<Metrics />} />
+                <Route path="/settings" element={<Settings />} />
+                <Route path="/users" element={<Users />} />
+                <Route path="/escolher-plano" element={<SelectPlan />} />
+                <Route path="/checkout" element={<Checkout />} />
+                <Route path="/planos" element={<Plans />} />
+                <Route path="/admin" element={<SuperAdmin />} />
 
-              <Route path="/super-admin" element={<SuperAdmin />} />
-              {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-              <Route path="*" element={<NotFound />} />
-            </Route>
-          </Routes>
-        </BrowserRouter>
-      </AuthProvider>
-    </TooltipProvider>
+                <Route path="/super-admin" element={<SuperAdmin />} />
+                {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+                <Route path="*" element={<NotFound />} />
+              </Route>
+            </Routes>
+          </BrowserRouter>
+        </AuthProvider>
+      </TooltipProvider>
+    </ThemeProvider>
   </QueryClientProvider>
 );
 

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -5,6 +5,7 @@ import SubscriptionBanner from "@/components/SubscriptionBanner";
 import TrialCountdownBanner from "@/components/TrialCountdownBanner";
 import { useSubscription, isFullyBlocked } from "@/hooks/useSubscription";
 import { useAuth } from "@/hooks/useAuth";
+import { ThemeToggle } from "@/components/ThemeToggle";
 
 export default function AppLayout() {
   const location = useLocation();
@@ -42,7 +43,7 @@ export default function AppLayout() {
   }
 
   return (
-    <div className="dark">
+    <>
       <TrialCountdownBanner />
       <SidebarProvider>
         <header className="h-12 flex items-center border-b border-border bg-background md:hidden">
@@ -50,6 +51,7 @@ export default function AppLayout() {
           <span className="ml-2 text-sm font-bold tracking-tight">
             Beauty<span className="bg-gradient-to-r from-primary-glow to-accent bg-clip-text text-transparent">Core</span>
           </span>
+          <ThemeToggle className="ml-auto mr-2" showLabel={false} />
         </header>
 
         <div className="flex min-h-screen w-full bg-background text-foreground">
@@ -62,6 +64,6 @@ export default function AppLayout() {
           </main>
         </div>
       </SidebarProvider>
-    </div>
+    </>
   );
 }

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -29,6 +29,7 @@ import {
   Package,
 } from "lucide-react";
 import { useAuth } from "@/hooks/useAuth";
+import { ThemeToggle } from "@/components/ThemeToggle";
 
 const groups = [
   {
@@ -139,6 +140,9 @@ export default function AppSidebar() {
       <SidebarSeparator />
 
       <SidebarFooter>
+        <div className="px-2 pb-2">
+          <ThemeToggle className="w-full border-sidebar-border bg-sidebar text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground" />
+        </div>
         <SidebarMenu>
           <SidebarMenuItem>
             <SidebarMenuButton

--- a/src/components/ClientCombobox.tsx
+++ b/src/components/ClientCombobox.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { Input } from "@/components/ui/input";
@@ -10,6 +10,40 @@ import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 
 interface ClientLite { id: string; name: string; phone?: string | null }
+
+const CLIENTS_PAGE_SIZE = 1000;
+const INITIAL_VISIBLE_CLIENTS = 50;
+const VISIBLE_CLIENTS_INCREMENT = 50;
+
+async function fetchAllClients(establishmentId: string) {
+  const allClients: ClientLite[] = [];
+  let from = 0;
+
+  while (true) {
+    const to = from + CLIENTS_PAGE_SIZE - 1;
+    const { data, error } = await supabase
+      .from("clients")
+      .select("id, name, phone")
+      .eq("establishment_id", establishmentId)
+      .order("name")
+      .range(from, to);
+
+    if (error) {
+      throw error;
+    }
+
+    const page = (data ?? []) as ClientLite[];
+    allClients.push(...page);
+
+    if (page.length < CLIENTS_PAGE_SIZE) {
+      break;
+    }
+
+    from += CLIENTS_PAGE_SIZE;
+  }
+
+  return allClients;
+}
 
 interface Props {
   establishmentId: string;
@@ -26,19 +60,17 @@ export function ClientCombobox({ establishmentId, value, onChange, compact = tru
   const [openCreate, setOpenCreate] = useState(false);
   const [form, setForm] = useState({ name: "", phone: "", acquisition_source: "" });
   const [saving, setSaving] = useState(false);
+  const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE_CLIENTS);
 
-  const { data: clients } = useQuery<ClientLite[]>({
+  const { data: clients, isLoading, isError } = useQuery<ClientLite[]>({
     queryKey: ["clients-combobox", establishmentId],
     enabled: !!establishmentId,
-    queryFn: async () => {
-      const { data } = await supabase
-        .from("clients")
-        .select("id, name, phone")
-        .eq("establishment_id", establishmentId)
-        .order("name");
-      return (data ?? []) as ClientLite[];
-    },
+    queryFn: () => fetchAllClients(establishmentId),
   });
+
+  useEffect(() => {
+    setVisibleCount(INITIAL_VISIBLE_CLIENTS);
+  }, [search, establishmentId]);
 
   const selected = clients?.find(c => c.id === value);
 
@@ -49,6 +81,13 @@ export function ClientCombobox({ establishmentId, value, onChange, compact = tru
       c.name.toLowerCase().includes(q) || (c.phone ?? "").toLowerCase().includes(q)
     );
   }, [clients, search]);
+
+  const visibleClients = useMemo(
+    () => filtered.slice(0, visibleCount),
+    [filtered, visibleCount]
+  );
+
+  const hasMoreClients = filtered.length > visibleClients.length;
 
   const openWithSearch = () => {
     setForm(f => ({ ...f, name: /^[a-zA-ZÀ-ÿ\s]+$/.test(search) ? search : f.name, phone: /^[\d\s()+\-]+$/.test(search) ? search : f.phone }));
@@ -108,7 +147,17 @@ export function ClientCombobox({ establishmentId, value, onChange, compact = tru
       </div>
 
       <div className="max-h-48 overflow-y-auto rounded-md border bg-background">
-        {filtered.slice(0, 8).map(c => (
+        {isLoading && (
+          <div className="px-3 py-3 text-sm text-muted-foreground text-center">
+            Carregando clientes...
+          </div>
+        )}
+        {isError && (
+          <div className="px-3 py-3 text-sm text-destructive text-center">
+            Erro ao carregar clientes.
+          </div>
+        )}
+        {!isLoading && !isError && visibleClients.map(c => (
           <button
             key={c.id}
             type="button"
@@ -119,10 +168,20 @@ export function ClientCombobox({ establishmentId, value, onChange, compact = tru
             {c.phone && <span className="text-xs text-muted-foreground">{c.phone}</span>}
           </button>
         ))}
-        {filtered.length === 0 && (
+        {!isLoading && !isError && filtered.length === 0 && (
           <div className="px-3 py-3 text-sm text-muted-foreground text-center">
             {search ? "Nenhum cliente encontrado." : "Digite para buscar..."}
           </div>
+        )}
+        {!isLoading && !isError && hasMoreClients && (
+          <Button
+            type="button"
+            variant="ghost"
+            className="w-full rounded-none text-xs text-muted-foreground"
+            onClick={() => setVisibleCount(count => count + VISIBLE_CLIENTS_INCREMENT)}
+          >
+            Mostrar mais {Math.min(VISIBLE_CLIENTS_INCREMENT, filtered.length - visibleClients.length)} de {filtered.length} clientes
+          </Button>
         )}
       </div>
 

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,0 +1,16 @@
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import type { ThemeProviderProps } from "next-themes";
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return (
+    <NextThemesProvider
+      attribute="class"
+      defaultTheme="dark"
+      enableSystem={false}
+      disableTransitionOnChange
+      {...props}
+    >
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface ThemeToggleProps {
+  className?: string;
+  showLabel?: boolean;
+}
+
+export function ThemeToggle({ className, showLabel = true }: ThemeToggleProps) {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const isDark = mounted ? theme !== "light" : true;
+  const nextTheme = isDark ? "light" : "dark";
+  const label = isDark ? "Modo claro" : "Modo escuro";
+  const Icon = isDark ? Sun : Moon;
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size={showLabel ? "sm" : "icon"}
+      className={cn("border-border bg-background/80 text-foreground", showLabel && "justify-start", className)}
+      onClick={() => setTheme(nextTheme)}
+      aria-label={`Alternar para ${label.toLowerCase()}`}
+      title={`Alternar para ${label.toLowerCase()}`}
+    >
+      <Icon className="h-4 w-4" />
+      {showLabel && <span>{label}</span>}
+    </Button>
+  );
+}

--- a/src/components/agenda/AgendaCalendar.tsx
+++ b/src/components/agenda/AgendaCalendar.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { Calendar, dateFnsLocalizer, View, SlotInfo } from "react-big-calendar";
 import { format, parse, startOfWeek, getDay } from "date-fns";
 import { ptBR } from "date-fns/locale";
@@ -37,14 +37,27 @@ export interface AgendaEvent {
 
 interface Props {
   events: AgendaEvent[];
+  view: View;
+  date: Date;
+  agendaLength?: number;
+  onViewChange: (view: View) => void;
+  onNavigate: (date: Date) => void;
   onSelectSlot: (slot: SlotInfo) => void;
   onSelectEvent: (event: AgendaEvent) => void;
   onRangeChange?: (range: { start: Date; end: Date }) => void;
 }
 
-export function AgendaCalendar({ events, onSelectSlot, onSelectEvent, onRangeChange }: Props) {
-  const [view, setView] = useState<View>("week");
-  const [date, setDate] = useState<Date>(new Date());
+export function AgendaCalendar({
+  events,
+  view,
+  date,
+  agendaLength,
+  onViewChange,
+  onNavigate,
+  onSelectSlot,
+  onSelectEvent,
+  onRangeChange,
+}: Props) {
 
   const eventPropGetter = useMemo(
     () => (event: AgendaEvent) => {
@@ -72,16 +85,17 @@ export function AgendaCalendar({ events, onSelectSlot, onSelectEvent, onRangeCha
         events={events}
         view={view}
         date={date}
-        onView={setView}
-        onNavigate={setDate}
+        onView={onViewChange}
+        onNavigate={onNavigate}
         views={["month", "week", "day", "agenda"]}
         defaultView="week"
         culture="pt-BR"
         messages={MESSAGES}
+        length={agendaLength}
         selectable
         onSelectSlot={onSelectSlot}
         onSelectEvent={(e) => onSelectEvent(e as AgendaEvent)}
-        onDrillDown={(d) => { setDate(d); setView("day"); }}
+        onDrillDown={(d) => { onNavigate(d); onViewChange("day"); }}
         onRangeChange={(range: any) => {
           if (Array.isArray(range) && range.length > 0) {
             onRangeChange?.(toFullDayRange(range[0], range[range.length - 1]));

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,11 +1,15 @@
 import { Toaster as Sonner, toast } from "sonner"
+import { useTheme } from "next-themes"
 
 type ToasterProps = React.ComponentProps<typeof Sonner>
 
 const Toaster = ({ ...props }: ToasterProps) => {
+  const { resolvedTheme, theme } = useTheme()
+  const activeTheme = resolvedTheme ?? theme
+
   return (
     <Sonner
-      theme={"system"}
+      theme={activeTheme === "light" ? "light" : "dark"}
       className="toaster group"
       toastOptions={{
         classNames: {

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -6,6 +6,7 @@ import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useAuth } from '@/hooks/useAuth';
+import { ThemeToggle } from '@/components/ThemeToggle';
 
 const Auth = () => {
   const { user, signIn, signUp } = useAuth();
@@ -70,7 +71,8 @@ const Auth = () => {
   };
 
   return (
-    <div className="dark min-h-screen bg-background text-foreground flex items-center justify-center p-4 relative overflow-hidden">
+    <div className="min-h-screen bg-background text-foreground flex items-center justify-center p-4 relative overflow-hidden">
+      <ThemeToggle className="absolute right-4 top-4 z-20" />
       <div className="pointer-events-none absolute inset-0 -z-10">
         <div className="absolute -top-40 -left-40 h-[500px] w-[500px] rounded-full bg-primary/20 blur-3xl" />
         <div className="absolute -bottom-40 -right-40 h-[500px] w-[500px] rounded-full bg-accent/15 blur-3xl" />

--- a/src/pages/components/AgendaContent.tsx
+++ b/src/pages/components/AgendaContent.tsx
@@ -1,8 +1,13 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { View } from "react-big-calendar";
+import { addDays, endOfDay, endOfMonth, endOfWeek, format, startOfDay, startOfMonth, startOfWeek, subDays } from "date-fns";
+import { ptBR } from "date-fns/locale";
 import { useAuth } from "@/hooks/useAuth";
 import { supabase } from "@/integrations/supabase/client";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { useToast } from "@/hooks/use-toast";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -15,17 +20,61 @@ import { AppointmentDetailsDialog } from "@/components/agenda/AppointmentDetails
 import ImportAppointmentsDialog from "@/components/agenda/ImportAppointmentsDialog";
 import { STATUS_LABELS, STATUS_VARIANTS, STATUS_OPTIONS, normalizeStatus } from "@/lib/appointmentStatus";
 
+type PeriodMode = "day" | "week" | "month" | "custom";
+type Professional = { id: string; name: string };
+
+const ALL_PROFESSIONALS = "all";
+const FILTER_STORAGE_KEY = "agenda.professionalFilter";
+
+const getWeekOptions = () => ({ locale: ptBR, weekStartsOn: 0 as const });
+
+function getRangeForPeriod(periodMode: PeriodMode, date: Date) {
+  if (periodMode === "day") {
+    return { start: startOfDay(date), end: endOfDay(date) };
+  }
+
+  if (periodMode === "month") {
+    return { start: startOfMonth(date), end: endOfMonth(date) };
+  }
+
+  return {
+    start: startOfWeek(date, getWeekOptions()),
+    end: endOfWeek(date, getWeekOptions()),
+  };
+}
+
+function toDateInputValue(date: Date) {
+  return format(date, "yyyy-MM-dd");
+}
+
+function fromDateInputValue(value: string, fallback: Date) {
+  if (!value) return fallback;
+  const [year, month, day] = value.split("-").map(Number);
+  if (!year || !month || !day) return fallback;
+  return new Date(year, month - 1, day);
+}
+
+function formatRangeLabel(start: Date, end: Date) {
+  return `${format(start, "dd/MM/yyyy")} até ${format(end, "dd/MM/yyyy")}`;
+}
+
 export default function AgendaContent() {
-  const { profile } = useAuth();
+  const { profile, establishmentRole, professionalId } = useAuth();
   const { toast } = useToast();
   const qc = useQueryClient();
   const establishmentId = profile?.id as string | undefined;
+  const isEmployee = establishmentRole === "employee";
 
   const [viewMode, setViewMode] = useState<"calendar" | "list">("calendar");
-  const [range, setRange] = useState<{ start: Date; end: Date }>(() => {
-    const s = new Date(); s.setDate(s.getDate() - s.getDay()); s.setHours(0, 0, 0, 0);
-    const e = new Date(s); e.setDate(e.getDate() + 6); e.setHours(23, 59, 59, 999);
-    return { start: s, end: e };
+  const [calendarView, setCalendarView] = useState<View>("week");
+  const [calendarDate, setCalendarDate] = useState<Date>(new Date());
+  const [periodMode, setPeriodMode] = useState<PeriodMode>("week");
+  const [range, setRange] = useState<{ start: Date; end: Date }>(() => getRangeForPeriod("week", new Date()));
+  const [customStart, setCustomStart] = useState(() => toDateInputValue(range.start));
+  const [customEnd, setCustomEnd] = useState(() => toDateInputValue(range.end));
+  const [selectedProfessionalId, setSelectedProfessionalId] = useState<string>(() => {
+    if (typeof window === "undefined") return ALL_PROFESSIONALS;
+    return window.localStorage.getItem(FILTER_STORAGE_KEY) || ALL_PROFESSIONALS;
   });
   const [formOpen, setFormOpen] = useState(false);
   const [detailsOpen, setDetailsOpen] = useState(false);
@@ -33,29 +82,143 @@ export default function AgendaContent() {
   const [selectedAppt, setSelectedAppt] = useState<any | null>(null);
   const [initialSlot, setInitialSlot] = useState<Date | null>(null);
 
-  const { data, isLoading, error } = useQuery({
-    queryKey: ["agenda", establishmentId, range.start.toISOString(), range.end.toISOString()],
+  const effectiveProfessionalId = isEmployee ? professionalId : selectedProfessionalId !== ALL_PROFESSIONALS ? selectedProfessionalId : null;
+
+  useEffect(() => {
+    if (!isEmployee || !professionalId) return;
+    setSelectedProfessionalId(professionalId);
+  }, [isEmployee, professionalId]);
+
+  useEffect(() => {
+    if (isEmployee || typeof window === "undefined") return;
+    window.localStorage.setItem(FILTER_STORAGE_KEY, selectedProfessionalId);
+  }, [isEmployee, selectedProfessionalId]);
+
+  useEffect(() => {
+    if (periodMode !== "custom") {
+      const nextRange = getRangeForPeriod(periodMode, calendarDate);
+      setRange(nextRange);
+      setCustomStart(toDateInputValue(nextRange.start));
+      setCustomEnd(toDateInputValue(nextRange.end));
+    }
+  }, [periodMode, calendarDate]);
+
+  useEffect(() => {
+    if (periodMode !== "custom") return;
+    const start = startOfDay(fromDateInputValue(customStart, range.start));
+    const end = endOfDay(fromDateInputValue(customEnd, range.end));
+
+    if (start <= end) {
+      setRange({ start, end });
+      setCalendarDate(start);
+    }
+  }, [customStart, customEnd, periodMode]);
+
+  const { data: professionals = [] } = useQuery<Professional[]>({
+    queryKey: ["agenda-professionals", establishmentId, isEmployee, professionalId],
     enabled: !!establishmentId,
     queryFn: async () => {
-      const [apptRes, servicesRes, profRes, clientsRes] = await Promise.all([
-        supabase.from("appointments").select("id, establishment_id, appointment_date, status, notes, client_id, service_id, professional_id")
-          .eq("establishment_id", establishmentId)
-          .gte("appointment_date", range.start.toISOString())
-          .lte("appointment_date", range.end.toISOString())
-          .order("appointment_date", { ascending: true }),
+      let query = supabase
+        .from("professionals")
+        .select("id, name")
+        .eq("establishment_id", establishmentId)
+        .eq("active", true)
+        .order("name");
+
+      if (isEmployee && professionalId) {
+        query = query.eq("id", professionalId);
+      }
+
+      const { data, error } = await query;
+      if (error) throw error;
+      return (data ?? []) as Professional[];
+    },
+  });
+
+  useEffect(() => {
+    if (isEmployee || selectedProfessionalId === ALL_PROFESSIONALS || professionals.length === 0) return;
+    if (!professionals.some(professional => professional.id === selectedProfessionalId)) {
+      setSelectedProfessionalId(ALL_PROFESSIONALS);
+    }
+  }, [isEmployee, professionals, selectedProfessionalId]);
+
+  const { data, isLoading, isFetching, error } = useQuery({
+    queryKey: ["agenda", establishmentId, range.start.toISOString(), range.end.toISOString(), effectiveProfessionalId],
+    enabled: !!establishmentId && (!isEmployee || !!professionalId),
+    queryFn: async () => {
+      const appointmentFields = "id, establishment_id, appointment_date, status, notes, client_id, service_id, professional_id";
+      const appointmentRangeQuery = () => supabase
+        .from("appointments")
+        .select(appointmentFields)
+        .eq("establishment_id", establishmentId)
+        .gte("appointment_date", range.start.toISOString())
+        .lte("appointment_date", range.end.toISOString())
+        .order("appointment_date", { ascending: true });
+
+      const appointmentsPromise = effectiveProfessionalId
+        ? Promise.all([
+            appointmentRangeQuery().eq("professional_id", effectiveProfessionalId),
+            supabase
+              .from("appointments")
+              .select(`${appointmentFields}, appointment_professionals!inner(professional_id)`)
+              .eq("establishment_id", establishmentId)
+              .eq("appointment_professionals.professional_id", effectiveProfessionalId)
+              .gte("appointment_date", range.start.toISOString())
+              .lte("appointment_date", range.end.toISOString())
+              .order("appointment_date", { ascending: true }),
+          ]).then(([primaryRes, linkedRes]) => {
+            if (primaryRes.error) return primaryRes;
+            if (linkedRes.error) return linkedRes;
+
+            const byId = new Map<string, any>();
+            [...(primaryRes.data ?? []), ...(linkedRes.data ?? [])].forEach((appointment: any) => {
+              byId.set(appointment.id, appointment);
+            });
+
+            return {
+              data: [...byId.values()].sort(
+                (a, b) => new Date(a.appointment_date).getTime() - new Date(b.appointment_date).getTime()
+              ),
+              error: null,
+            };
+          })
+        : appointmentRangeQuery();
+
+      let professionalsQuery = supabase
+        .from("professionals")
+        .select("id, name")
+        .eq("establishment_id", establishmentId)
+        .eq("active", true)
+        .order("name");
+
+      if (isEmployee && professionalId) {
+        professionalsQuery = professionalsQuery.eq("id", professionalId);
+      }
+
+      const [apptRes, servicesRes, profRes] = await Promise.all([
+        appointmentsPromise,
         supabase.from("services").select("id, name, duration_minutes").eq("establishment_id", establishmentId).eq("active", true),
-        supabase.from("professionals").select("id, name").eq("establishment_id", establishmentId).eq("active", true),
-        supabase.from("clients").select("id, name").eq("establishment_id", establishmentId).order("name"),
+        professionalsQuery,
       ]);
+
       if (apptRes.error) throw apptRes.error;
+      if (servicesRes.error) throw servicesRes.error;
+      if (profRes.error) throw profRes.error;
+
       const appts = apptRes.data ?? [];
       const services = servicesRes.data ?? [];
-      const professionals = profRes.data ?? [];
-      const clients = clientsRes.data ?? [];
+      const activeProfessionals = (profRes.data ?? []) as Professional[];
+      const clientIds = [...new Set(appts.map((appt: any) => appt.client_id).filter(Boolean))];
+      const clientsRes = clientIds.length
+        ? await supabase.from("clients").select("id, name").in("id", clientIds)
+        : { data: [], error: null };
+
+      if (clientsRes.error) throw clientsRes.error;
+
       const serviceMap = new Map(services.map((s: any) => [s.id, s]));
-      const profMap = new Map(professionals.map((p: any) => [p.id, p.name]));
-      const clientMap = new Map(clients.map((c: any) => [c.id, c.name]));
-      return { appts, serviceMap, profMap, clientMap, services, professionals, clients };
+      const profMap = new Map(activeProfessionals.map((p: any) => [p.id, p.name]));
+      const clientMap = new Map(((clientsRes.data ?? []) as any[]).map((c: any) => [c.id, c.name]));
+      return { appts, serviceMap, profMap, clientMap, services, professionals: activeProfessionals };
     },
   });
 
@@ -71,6 +234,10 @@ export default function AgendaContent() {
       return { id: a.id, title: `${client} · ${sname}`, start, end, status: a.status, raw: a };
     });
   }, [data]);
+
+  const selectedProfessionalName = effectiveProfessionalId
+    ? professionals.find(professional => professional.id === effectiveProfessionalId)?.name ?? "Profissional"
+    : "Todos os profissionais";
 
   const slug = (profile as any)?.slug as string | undefined;
   const publicLink = establishmentId ? `${window.location.origin}/${slug ?? `agendar/${establishmentId}`}` : "";
@@ -90,6 +257,44 @@ export default function AgendaContent() {
     const { error } = await supabase.from("appointments").update({ status }).eq("id", id);
     if (error) { toast({ title: "Erro", description: error.message, variant: "destructive" }); return; }
     refresh();
+  };
+
+  const handlePeriodChange = (value: string) => {
+    const nextPeriod = value as PeriodMode;
+    setPeriodMode(nextPeriod);
+
+    if (nextPeriod === "day") {
+      setCalendarView("day");
+    } else if (nextPeriod === "month") {
+      setCalendarView("month");
+    } else if (nextPeriod === "custom") {
+      setCalendarView("agenda");
+    } else {
+      setCalendarView("week");
+    }
+  };
+
+  const handleCalendarViewChange = (view: View) => {
+    setCalendarView(view);
+    if (view === "day" || view === "week" || view === "month") {
+      setPeriodMode(view);
+    }
+  };
+
+  const handleCalendarRangeChange = (nextRange: { start: Date; end: Date }) => {
+    if (periodMode === "custom") return;
+    setRange(nextRange);
+    setCustomStart(toDateInputValue(nextRange.start));
+    setCustomEnd(toDateInputValue(nextRange.end));
+  };
+
+  const navigateCustomRange = (direction: "previous" | "next") => {
+    const days = Math.max(1, Math.round((range.end.getTime() - range.start.getTime()) / 86_400_000) + 1);
+    const move = direction === "next" ? addDays : subDays;
+    const nextStart = move(range.start, days);
+    const nextEnd = move(range.end, days);
+    setCustomStart(toDateInputValue(nextStart));
+    setCustomEnd(toDateInputValue(nextEnd));
   };
 
   if (!establishmentId) return <div className="rounded-md border p-6 bg-card text-sm text-muted-foreground">Carregando perfil...</div>;
@@ -112,6 +317,65 @@ export default function AgendaContent() {
         </div>
       </div>
 
+      <div className="rounded-md border bg-card p-4 space-y-4">
+        <div className="grid gap-4 md:grid-cols-[minmax(220px,1fr)_220px_minmax(260px,1fr)]">
+          <div className="space-y-2">
+            <Label>Profissional</Label>
+            <Select
+              value={isEmployee ? professionalId ?? "" : selectedProfessionalId}
+              onValueChange={setSelectedProfessionalId}
+              disabled={isEmployee}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Selecione um profissional" />
+              </SelectTrigger>
+              <SelectContent>
+                {!isEmployee && <SelectItem value={ALL_PROFESSIONALS}>Todos os profissionais</SelectItem>}
+                {professionals.map(professional => (
+                  <SelectItem key={professional.id} value={professional.id}>{professional.name}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Período</Label>
+            <Select value={periodMode} onValueChange={handlePeriodChange}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="day">Dia</SelectItem>
+                <SelectItem value="week">Semana</SelectItem>
+                <SelectItem value="month">Mês</SelectItem>
+                <SelectItem value="custom">Intervalo personalizado</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label>{periodMode === "custom" ? "Intervalo" : "Período atual"}</Label>
+            {periodMode === "custom" ? (
+              <div className="flex flex-wrap items-center gap-2">
+                <Input className="w-[145px]" type="date" value={customStart} onChange={(event) => setCustomStart(event.target.value)} />
+                <span className="text-sm text-muted-foreground">até</span>
+                <Input className="w-[145px]" type="date" value={customEnd} onChange={(event) => setCustomEnd(event.target.value)} />
+                <Button type="button" variant="outline" size="sm" onClick={() => navigateCustomRange("previous")}>Anterior</Button>
+                <Button type="button" variant="outline" size="sm" onClick={() => navigateCustomRange("next")}>Próximo</Button>
+              </div>
+            ) : (
+              <div className="flex min-h-10 items-center rounded-md border bg-muted/40 px-3 text-sm">
+                {formatRangeLabel(range.start, range.end)}
+              </div>
+            )}
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center justify-between gap-2 text-sm text-muted-foreground">
+          <span>Exibindo {events.length} agendamento(s) para <strong className="text-foreground">{selectedProfessionalName}</strong>.</span>
+          {isFetching && <span>Atualizando agenda...</span>}
+        </div>
+      </div>
+
       {isLoading ? (
         <div className="rounded-md border p-6 bg-card text-sm text-muted-foreground">Carregando agendamentos...</div>
       ) : error ? (
@@ -119,9 +383,14 @@ export default function AgendaContent() {
       ) : viewMode === "calendar" ? (
         <AgendaCalendar
           events={events}
+          view={calendarView}
+          date={calendarDate}
+          agendaLength={Math.max(1, Math.round((range.end.getTime() - range.start.getTime()) / 86_400_000) + 1)}
+          onViewChange={handleCalendarViewChange}
+          onNavigate={setCalendarDate}
           onSelectSlot={handleSlot}
           onSelectEvent={handleEventClick}
-          onRangeChange={(r) => setRange(r)}
+          onRangeChange={handleCalendarRangeChange}
         />
       ) : (
         <div className="rounded-md border overflow-x-auto">

--- a/supabase/migrations/20260601143000_add_appointment_professional_filter_index.sql
+++ b/supabase/migrations/20260601143000_add_appointment_professional_filter_index.sql
@@ -1,0 +1,4 @@
+-- Speeds up agenda filtering by professional when appointments use the
+-- appointment_professionals join table for multi-professional bookings.
+CREATE INDEX IF NOT EXISTS idx_appointment_professionals_prof_est
+ON public.appointment_professionals (professional_id, establishment_id);


### PR DESCRIPTION
### Motivation
- Introduce application-level theme support and a user-visible theme toggle so users can switch between light and dark modes consistently.
- Improve the agenda UI to support controlled calendar view/date, professional filtering, custom ranges, and better handling of multi-professional appointments.
- Make the client combobox scalable for large datasets by paginating the Supabase queries, adding a "show more" UX, and surfacing loading/error states.
- Add a DB index to speed up filtering by professional when appointments use the `appointment_professionals` join table.

### Description
- Added `ThemeProvider` (wrapping `next-themes`) and `ThemeToggle` components, wired into `App`, `AppSidebar`, `AppLayout` header, and `Auth` page, and updated the Sonner toaster to respect the current theme via `useTheme`.
- Reworked `ClientCombobox` to fetch clients in pages via `fetchAllClients`, maintain a `visibleCount` with a "Mostrar mais" button, reset visibility on search/establishment change, and show loading/error messages.
- Converted `AgendaCalendar` to a controlled component with `view`, `date`, `agendaLength`, `onViewChange`, and `onNavigate` props and forwarded drill-down and range change events to callers.
- Extended `AgendaContent` with professional filtering (including persisting non-employee filter to `localStorage`), period modes (`day`/`week`/`month`/`custom`), calendar navigation helpers, consolidated appointment queries to include results from both primary and `appointment_professionals` join queries, and added professional/service/client maps for display.
- Minor layout updates: removed hardcoded `dark` wrapper, inserted `ThemeToggle` in mobile header and sidebar footer, and small UI/UX string and behavior tweaks.
- Added a Supabase migration `20260601143000_add_appointment_professional_filter_index.sql` to create `idx_appointment_professionals_prof_est` for `(professional_id, establishment_id)`.

### Testing
- Ran TypeScript type-check with `tsc --noEmit` and a development build with `yarn build`, both completed without type/build errors.
- Executed the existing automated test suite with `yarn test`, and all tests passed.
- Verified interactive flows locally (theme toggle, client search/load more, agenda period/professional filter and navigation) during development to ensure the new controlled calendar and queries behave as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d8f927cc0832f9ab50c0eca209d00)