### PR TITLE
Fix mobile scrolling for client lists

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -45,7 +45,7 @@ export default function AppLayout() {
   return (
     <>
       <TrialCountdownBanner />
-      <SidebarProvider>
+      <SidebarProvider className="flex-col md:flex-row">
         <header className="h-12 flex items-center border-b border-border bg-background md:hidden">
           <SidebarTrigger className="ml-2 text-foreground" />
           <span className="ml-2 text-sm font-bold tracking-tight">
@@ -54,11 +54,11 @@ export default function AppLayout() {
           <ThemeToggle className="ml-auto mr-2" showLabel={false} />
         </header>
 
-        <div className="flex min-h-screen w-full bg-background text-foreground">
+        <div className="flex min-h-[calc(100svh-3rem)] w-full min-w-0 bg-background text-foreground md:min-h-svh">
           <AppSidebar />
-          <main className="flex-1 flex flex-col">
+          <main className="flex min-w-0 flex-1 flex-col">
             <SubscriptionBanner />
-            <div className="flex-1">
+            <div className="min-w-0 flex-1">
               <Outlet />
             </div>
           </main>

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -6,7 +6,9 @@ const Table = React.forwardRef<
   HTMLTableElement,
   React.HTMLAttributes<HTMLTableElement>
 >(({ className, ...props }, ref) => (
-  <div className="relative w-full overflow-auto">
+  <div
+    className="relative w-full min-w-0 overflow-x-auto overflow-y-hidden overscroll-x-contain [-webkit-overflow-scrolling:touch] [touch-action:pan-x_pan-y]"
+  >
     <table
       ref={ref}
       className={cn("w-full caption-bottom text-sm", className)}

--- a/src/pages/Clients.tsx
+++ b/src/pages/Clients.tsx
@@ -422,52 +422,103 @@ const Clients = () => {
               </CardTitle>
             </CardHeader>
             <CardContent>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Nome</TableHead>
-                    <TableHead>Telefone</TableHead>
-                    <TableHead>Email</TableHead>
-                    <TableHead>Status</TableHead>
-                    <TableHead>Origem</TableHead>
-                    <TableHead>Total Gasto</TableHead>
-                    <TableHead>Visitas</TableHead>
-                    <TableHead>Ações</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {filteredClients.map((client) => (
-                    <TableRow key={client.id}>
-                      <TableCell className="font-medium">{client.name}</TableCell>
-                      <TableCell>{client.phone}</TableCell>
-                      <TableCell>{client.email || '-'}</TableCell>
-                      <TableCell>{getStatusBadge(client.last_service_date)}</TableCell>
-                      <TableCell>{ACQUISITION_SOURCES.find(s => s.value === (client as any).acquisition_source)?.label || '-'}</TableCell>
-                      <TableCell>R$ {Number(client.total_spent).toFixed(2)}</TableCell>
-                      <TableCell>{client.visit_count}</TableCell>
-                      <TableCell>
-                        <div className="flex gap-2">
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={() => handleEditClient(client)}
-                          >
-                            <Edit className="h-4 w-4" />
-                          </Button>
-                          <Button
-                            size="sm"
-                            onClick={() => openWhatsApp(client.phone, client.name)}
-                            className="bg-green-600 hover:bg-green-700"
-                          >
-                            <MessageCircle className="h-4 w-4 mr-1" />
-                            WhatsApp
-                          </Button>
-                        </div>
-                      </TableCell>
+              <div className="grid gap-3 md:hidden">
+                {filteredClients.map((client) => (
+                  <article key={client.id} className="rounded-lg border bg-card p-4 shadow-sm">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <h3 className="truncate font-semibold">{client.name}</h3>
+                        <p className="text-sm text-muted-foreground">{client.phone}</p>
+                        <p className="truncate text-sm text-muted-foreground">{client.email || 'Sem email'}</p>
+                      </div>
+                      <div className="shrink-0">{getStatusBadge(client.last_service_date)}</div>
+                    </div>
+
+                    <dl className="mt-4 grid grid-cols-2 gap-3 text-sm">
+                      <div>
+                        <dt className="text-muted-foreground">Origem</dt>
+                        <dd className="font-medium">{ACQUISITION_SOURCES.find(s => s.value === (client as any).acquisition_source)?.label || '-'}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-muted-foreground">Total gasto</dt>
+                        <dd className="font-medium">R$ {Number(client.total_spent).toFixed(2)}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-muted-foreground">Visitas</dt>
+                        <dd className="font-medium">{client.visit_count}</dd>
+                      </div>
+                    </dl>
+
+                    <div className="mt-4 grid grid-cols-2 gap-2">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => handleEditClient(client)}
+                      >
+                        <Edit className="h-4 w-4 mr-2" />
+                        Editar
+                      </Button>
+                      <Button
+                        size="sm"
+                        onClick={() => openWhatsApp(client.phone, client.name)}
+                        className="bg-green-600 hover:bg-green-700"
+                      >
+                        <MessageCircle className="h-4 w-4 mr-2" />
+                        WhatsApp
+                      </Button>
+                    </div>
+                  </article>
+                ))}
+              </div>
+
+              <div className="hidden md:block">
+                <Table className="min-w-[900px]">
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Nome</TableHead>
+                      <TableHead>Telefone</TableHead>
+                      <TableHead>Email</TableHead>
+                      <TableHead>Status</TableHead>
+                      <TableHead>Origem</TableHead>
+                      <TableHead>Total Gasto</TableHead>
+                      <TableHead>Visitas</TableHead>
+                      <TableHead>Ações</TableHead>
                     </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
+                  </TableHeader>
+                  <TableBody>
+                    {filteredClients.map((client) => (
+                      <TableRow key={client.id}>
+                        <TableCell className="font-medium">{client.name}</TableCell>
+                        <TableCell>{client.phone}</TableCell>
+                        <TableCell>{client.email || '-'}</TableCell>
+                        <TableCell>{getStatusBadge(client.last_service_date)}</TableCell>
+                        <TableCell>{ACQUISITION_SOURCES.find(s => s.value === (client as any).acquisition_source)?.label || '-'}</TableCell>
+                        <TableCell>R$ {Number(client.total_spent).toFixed(2)}</TableCell>
+                        <TableCell>{client.visit_count}</TableCell>
+                        <TableCell>
+                          <div className="flex gap-2">
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => handleEditClient(client)}
+                            >
+                              <Edit className="h-4 w-4" />
+                            </Button>
+                            <Button
+                              size="sm"
+                              onClick={() => openWhatsApp(client.phone, client.name)}
+                              className="bg-green-600 hover:bg-green-700"
+                            >
+                              <MessageCircle className="h-4 w-4 mr-1" />
+                              WhatsApp
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
             </CardContent>
           </Card>
         )}


### PR DESCRIPTION
### Motivation
- Mobile users reported scrolling issues on wide lists (clients table) where horizontal overflow blocked vertical touch scroll; the changes aim to restore natural touch scrolling and prevent layout overflow on small screens. 
- Provide a better mobile-first UX for the clients list so actions remain accessible without forcing horizontal scroll.

### Description
- Adjusted app shell sizing and layout to allow mobile vertical scrolling and prevent horizontal overflow by adding `min-w-0`, `min-h-[calc(100svh-3rem)]`, and setting the `SidebarProvider` stack behavior (`className="flex-col md:flex-row"`) in `src/components/AppLayout.tsx`.
- Made the shared table wrapper touch-friendly and contained horizontal overscroll by replacing the table container with classes: `overflow-x-auto overflow-y-hidden overscroll-x-contain [-webkit-overflow-scrolling:touch] [touch-action:pan-x_pan-y]` in `src/components/ui/table.tsx`.
- Replaced the full-width table on small screens with stacked responsive client cards (wrapped in `md:hidden`) and kept the desktop table under `hidden md:block` with a `min-w-[900px]` fallback in `src/pages/Clients.tsx` so mobile users see a native list UI while desktop keeps the tabular layout.
- Files changed: `src/components/AppLayout.tsx`, `src/components/ui/table.tsx`, `src/pages/Clients.tsx`.

### Testing
- Ran `git diff --check` and verified there are no whitespace issues.
- Attempted `npm run lint` but it failed due to environment/dependency resolution (`@eslint/js` missing); lint could not complete in this environment.
- Tried `npm install` / `npm ci` and `npm run build` to validate runtime and build, but these could not complete here because dependencies and `vite` were not available or lockfile was out-of-sync, so build/lint validation is pending in CI or a dev machine with dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a202a63c8ac8327880a64d6f77f02a8)