### PR TITLE
Make layout and tables responsive; enrich AdminDashboard with plan-aware MRR and plan breakdown

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -45,7 +45,7 @@ export default function AppLayout() {
   return (
     <>
       <TrialCountdownBanner />
-      <SidebarProvider>
+      <SidebarProvider className="flex-col md:flex-row">
         <header className="h-12 flex items-center border-b border-border bg-background md:hidden">
           <SidebarTrigger className="ml-2 text-foreground" />
           <span className="ml-2 text-sm font-bold tracking-tight">
@@ -54,11 +54,11 @@ export default function AppLayout() {
           <ThemeToggle className="ml-auto mr-2" showLabel={false} />
         </header>
 
-        <div className="flex min-h-screen w-full bg-background text-foreground">
+        <div className="flex min-h-[calc(100svh-3rem)] w-full min-w-0 bg-background text-foreground md:min-h-svh">
           <AppSidebar />
-          <main className="flex-1 flex flex-col">
+          <main className="flex min-w-0 flex-1 flex-col">
             <SubscriptionBanner />
-            <div className="flex-1">
+            <div className="min-w-0 flex-1">
               <Outlet />
             </div>
           </main>

--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -12,10 +12,15 @@ type Sub = {
   started_at: string;
   canceled_at: string | null;
   plan_id: string | null;
-  plan?: { monthly_price: number } | null;
+  plan?: { monthly_price: number; name?: string; slug?: string } | null;
 };
-type Profile = { id: string; created_at: string; plan?: string | null };
-type Plan = { id: string; slug: string; monthly_price: number };
+type Profile = {
+  id: string;
+  created_at: string;
+  plan?: string | null;
+  selected_plan_slug?: string | null;
+};
+type Plan = { id: string; name: string; slug: string; monthly_price: number; display_order: number };
 
 export default function AdminDashboard() {
   const metrics = useQuery({
@@ -24,33 +29,53 @@ export default function AdminDashboard() {
       const [{ data: subs, error: subsError }, { data: profiles, error: profilesError }, { data: plans, error: plansError }] = await Promise.all([
         (supabase as any)
           .from("subscriptions")
-          .select("establishment_id, status, monthly_amount, started_at, canceled_at, plan_id, subscription_plans!subscriptions_plan_id_fkey(monthly_price)"),
-        (supabase as any).from("profiles").select("id, created_at, plan"),
-        (supabase as any).from("subscription_plans").select("id, slug, monthly_price"),
+          .select("establishment_id, status, monthly_amount, started_at, canceled_at, plan_id, subscription_plans!subscriptions_plan_id_fkey(id, name, slug, monthly_price, display_order)"),
+        (supabase as any).from("profiles").select("id, created_at, plan, selected_plan_slug"),
+        (supabase as any).from("subscription_plans").select("id, name, slug, monthly_price, display_order").order("display_order"),
       ]);
       if (subsError) throw subsError;
       if (profilesError) throw profilesError;
       if (plansError) throw plansError;
 
+      const plansById = new Map<string, Plan>();
       const plansBySlug = new Map<string, Plan>();
-      (plans ?? []).forEach((p: Plan) => plansBySlug.set(p.slug, p));
+      (plans ?? []).forEach((p: Plan) => {
+        plansById.set(p.id, p);
+        plansBySlug.set(p.slug, p);
+      });
+
+      const getProfilePlan = (profile: Profile) => {
+        const selectedSlug = profile.selected_plan_slug || (profile.plan !== "trial" ? profile.plan : null);
+        return selectedSlug ? plansBySlug.get(selectedSlug) : undefined;
+      };
+
       const subsByEstablishment = new Map<string, Sub>();
       (subs ?? []).forEach((s: any) => {
+        const relationPlan = s.subscription_plans as Plan | null;
+        const plan = relationPlan ?? (s.plan_id ? plansById.get(s.plan_id) : undefined);
         subsByEstablishment.set(s.establishment_id, {
           establishment_id: s.establishment_id,
           status: s.status,
-          monthly_amount: Number(s.monthly_amount || s.subscription_plans?.monthly_price || 0),
+          monthly_amount: Number(s.monthly_amount || plan?.monthly_price || 0),
           started_at: s.started_at,
           canceled_at: s.canceled_at,
-          plan_id: s.plan_id,
-          plan: s.subscription_plans,
+          plan_id: s.plan_id ?? plan?.id ?? null,
+          plan: plan ? { monthly_price: plan.monthly_price, name: plan.name, slug: plan.slug } : null,
         });
       });
 
       const list = (profiles ?? []).map((p: Profile) => {
         const sub = subsByEstablishment.get(p.id);
-        if (sub) return sub;
-        const chosenPlan = p.plan && p.plan !== "trial" ? plansBySlug.get(p.plan) : undefined;
+        const chosenPlan = getProfilePlan(p);
+        const plan = sub?.plan ?? (chosenPlan ? { monthly_price: chosenPlan.monthly_price, name: chosenPlan.name, slug: chosenPlan.slug } : null);
+        if (sub) {
+          return {
+            ...sub,
+            monthly_amount: Number(sub.monthly_amount || chosenPlan?.monthly_price || 0),
+            plan_id: sub.plan_id ?? chosenPlan?.id ?? null,
+            plan,
+          } satisfies Sub;
+        }
         return {
           establishment_id: p.id,
           status: "trial",
@@ -58,22 +83,24 @@ export default function AdminDashboard() {
           started_at: p.created_at,
           canceled_at: null,
           plan_id: chosenPlan?.id ?? null,
-          plan: chosenPlan ? { monthly_price: chosenPlan.monthly_price } : null,
+          plan,
         } satisfies Sub;
       });
 
-      return { list, profiles: (profiles ?? []) as Profile[] };
+      return { list, profiles: (profiles ?? []) as Profile[], plans: (plans ?? []) as Plan[] };
     },
   });
 
   const list = metrics.data?.list ?? [];
   const profiles = metrics.data?.profiles ?? [];
+  const plans = metrics.data?.plans ?? [];
   const active = list.filter((s) => s.status === "active");
   const trial = list.filter((s) => s.status === "trial");
   const canceled = list.filter((s) => s.status === "canceled");
-  const billablePotential = list.filter((s) => !["canceled", "blocked"].includes(s.status));
+  const potentialStatuses = new Set(["trial", "active"]);
+  const potentialList = list.filter((s) => potentialStatuses.has(s.status));
   const mrr = active.reduce((sum, s) => sum + Number(s.monthly_amount || 0), 0);
-  const potentialMrr = billablePotential.reduce((sum, s) => sum + Number(s.monthly_amount || s.plan?.monthly_price || 0), 0);
+  const potentialMrr = potentialList.reduce((sum, s) => sum + Number(s.monthly_amount || s.plan?.monthly_price || 0), 0);
   const arr = mrr * 12;
   const arpu = active.length > 0 ? mrr / active.length : 0;
   const totalCompanies = profiles.length;
@@ -94,7 +121,7 @@ export default function AdminDashboard() {
         .filter((s) => s.status === "active")
         .reduce((sum, s) => sum + Number(s.monthly_amount || 0), 0);
       const monthPotential = eligible
-        .filter((s) => !["canceled", "blocked"].includes(s.status))
+        .filter((s) => potentialStatuses.has(s.status))
         .reduce((sum, s) => sum + Number(s.monthly_amount || s.plan?.monthly_price || 0), 0);
       months.push({
         label: d.toLocaleDateString("pt-BR", { month: "short" }),
@@ -138,9 +165,32 @@ export default function AdminDashboard() {
     ? (active.length / (trial.length + active.length)) * 100
     : 0;
 
+  const planCounts = (() => {
+    const counts = new Map<string, { planId: string | null; name: string; price: number; total: number; active: number; trial: number }>();
+    plans.forEach((plan) => {
+      counts.set(plan.id, { planId: plan.id, name: plan.name, price: plan.monthly_price, total: 0, active: 0, trial: 0 });
+    });
+    list.forEach((sub) => {
+      const key = sub.plan_id ?? sub.plan?.slug ?? "no-plan";
+      const current = counts.get(key) ?? {
+        planId: sub.plan_id,
+        name: sub.plan?.name ?? "Sem plano definido",
+        price: Number(sub.plan?.monthly_price || sub.monthly_amount || 0),
+        total: 0,
+        active: 0,
+        trial: 0,
+      };
+      current.total += 1;
+      if (sub.status === "active") current.active += 1;
+      if (sub.status === "trial") current.trial += 1;
+      counts.set(key, current);
+    });
+    return Array.from(counts.values()).filter((item) => item.total > 0);
+  })();
+
   const kpis = [
     { label: "MRR", value: fmtBRL(mrr), icon: DollarSign, tone: "text-accent" },
-    { label: "Potencial de faturamento", value: fmtBRL(potentialMrr), icon: Target, tone: "text-success" },
+    { label: "Potencial de MRR", value: fmtBRL(potentialMrr), icon: Target, tone: "text-success" },
     { label: "ARR", value: fmtBRL(arr), icon: TrendingUp, tone: "text-primary-glow" },
     { label: "Ticket médio (ARPU)", value: fmtBRL(arpu), icon: TrendingUp, tone: "text-accent" },
     { label: "Empresas ativas", value: active.length, icon: Building2, tone: "text-success" },
@@ -193,6 +243,40 @@ export default function AdminDashboard() {
           </CardContent>
         </Card>
       </div>
+
+      <Card className="bg-card/60 border-border/60">
+        <CardHeader>
+          <CardTitle className="text-base">Negócios por plano</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+            {planCounts.map((plan) => (
+              <div key={plan.planId ?? plan.name} className="rounded-lg border border-border/60 bg-background/50 p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="font-semibold">{plan.name}</div>
+                    <div className="text-xs text-muted-foreground">{fmtBRL(plan.price)}/mês</div>
+                  </div>
+                  <div className="text-right">
+                    <div className="text-2xl font-bold text-primary-glow">{plan.total}</div>
+                    <div className="text-xs text-muted-foreground">negócio{plan.total !== 1 ? "s" : ""}</div>
+                  </div>
+                </div>
+                <div className="mt-3 grid grid-cols-2 gap-2 text-sm">
+                  <div className="rounded-md bg-success/10 px-3 py-2">
+                    <div className="font-semibold text-success">{plan.active}</div>
+                    <div className="text-xs text-muted-foreground">ativos</div>
+                  </div>
+                  <div className="rounded-md bg-accent/10 px-3 py-2">
+                    <div className="font-semibold text-accent">{plan.trial}</div>
+                    <div className="text-xs text-muted-foreground">trials</div>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
 
       <div className="grid gap-4 lg:grid-cols-2">
         <Card className="bg-card/60 border-border/60">

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -6,7 +6,9 @@ const Table = React.forwardRef<
   HTMLTableElement,
   React.HTMLAttributes<HTMLTableElement>
 >(({ className, ...props }, ref) => (
-  <div className="relative w-full overflow-auto">
+  <div
+    className="relative w-full min-w-0 overflow-x-auto overflow-y-hidden overscroll-x-contain [-webkit-overflow-scrolling:touch] [touch-action:pan-x_pan-y]"
+  >
     <table
       ref={ref}
       className={cn("w-full caption-bottom text-sm", className)}

--- a/src/pages/Clients.tsx
+++ b/src/pages/Clients.tsx
@@ -422,52 +422,103 @@ const Clients = () => {
               </CardTitle>
             </CardHeader>
             <CardContent>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Nome</TableHead>
-                    <TableHead>Telefone</TableHead>
-                    <TableHead>Email</TableHead>
-                    <TableHead>Status</TableHead>
-                    <TableHead>Origem</TableHead>
-                    <TableHead>Total Gasto</TableHead>
-                    <TableHead>Visitas</TableHead>
-                    <TableHead>Ações</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {filteredClients.map((client) => (
-                    <TableRow key={client.id}>
-                      <TableCell className="font-medium">{client.name}</TableCell>
-                      <TableCell>{client.phone}</TableCell>
-                      <TableCell>{client.email || '-'}</TableCell>
-                      <TableCell>{getStatusBadge(client.last_service_date)}</TableCell>
-                      <TableCell>{ACQUISITION_SOURCES.find(s => s.value === (client as any).acquisition_source)?.label || '-'}</TableCell>
-                      <TableCell>R$ {Number(client.total_spent).toFixed(2)}</TableCell>
-                      <TableCell>{client.visit_count}</TableCell>
-                      <TableCell>
-                        <div className="flex gap-2">
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={() => handleEditClient(client)}
-                          >
-                            <Edit className="h-4 w-4" />
-                          </Button>
-                          <Button
-                            size="sm"
-                            onClick={() => openWhatsApp(client.phone, client.name)}
-                            className="bg-green-600 hover:bg-green-700"
-                          >
-                            <MessageCircle className="h-4 w-4 mr-1" />
-                            WhatsApp
-                          </Button>
-                        </div>
-                      </TableCell>
+              <div className="grid gap-3 md:hidden">
+                {filteredClients.map((client) => (
+                  <article key={client.id} className="rounded-lg border bg-card p-4 shadow-sm">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <h3 className="truncate font-semibold">{client.name}</h3>
+                        <p className="text-sm text-muted-foreground">{client.phone}</p>
+                        <p className="truncate text-sm text-muted-foreground">{client.email || 'Sem email'}</p>
+                      </div>
+                      <div className="shrink-0">{getStatusBadge(client.last_service_date)}</div>
+                    </div>
+
+                    <dl className="mt-4 grid grid-cols-2 gap-3 text-sm">
+                      <div>
+                        <dt className="text-muted-foreground">Origem</dt>
+                        <dd className="font-medium">{ACQUISITION_SOURCES.find(s => s.value === (client as any).acquisition_source)?.label || '-'}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-muted-foreground">Total gasto</dt>
+                        <dd className="font-medium">R$ {Number(client.total_spent).toFixed(2)}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-muted-foreground">Visitas</dt>
+                        <dd className="font-medium">{client.visit_count}</dd>
+                      </div>
+                    </dl>
+
+                    <div className="mt-4 grid grid-cols-2 gap-2">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => handleEditClient(client)}
+                      >
+                        <Edit className="h-4 w-4 mr-2" />
+                        Editar
+                      </Button>
+                      <Button
+                        size="sm"
+                        onClick={() => openWhatsApp(client.phone, client.name)}
+                        className="bg-green-600 hover:bg-green-700"
+                      >
+                        <MessageCircle className="h-4 w-4 mr-2" />
+                        WhatsApp
+                      </Button>
+                    </div>
+                  </article>
+                ))}
+              </div>
+
+              <div className="hidden md:block">
+                <Table className="min-w-[900px]">
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Nome</TableHead>
+                      <TableHead>Telefone</TableHead>
+                      <TableHead>Email</TableHead>
+                      <TableHead>Status</TableHead>
+                      <TableHead>Origem</TableHead>
+                      <TableHead>Total Gasto</TableHead>
+                      <TableHead>Visitas</TableHead>
+                      <TableHead>Ações</TableHead>
                     </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
+                  </TableHeader>
+                  <TableBody>
+                    {filteredClients.map((client) => (
+                      <TableRow key={client.id}>
+                        <TableCell className="font-medium">{client.name}</TableCell>
+                        <TableCell>{client.phone}</TableCell>
+                        <TableCell>{client.email || '-'}</TableCell>
+                        <TableCell>{getStatusBadge(client.last_service_date)}</TableCell>
+                        <TableCell>{ACQUISITION_SOURCES.find(s => s.value === (client as any).acquisition_source)?.label || '-'}</TableCell>
+                        <TableCell>R$ {Number(client.total_spent).toFixed(2)}</TableCell>
+                        <TableCell>{client.visit_count}</TableCell>
+                        <TableCell>
+                          <div className="flex gap-2">
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => handleEditClient(client)}
+                            >
+                              <Edit className="h-4 w-4" />
+                            </Button>
+                            <Button
+                              size="sm"
+                              onClick={() => openWhatsApp(client.phone, client.name)}
+                              className="bg-green-600 hover:bg-green-700"
+                            >
+                              <MessageCircle className="h-4 w-4 mr-1" />
+                              WhatsApp
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
             </CardContent>
           </Card>
         )}


### PR DESCRIPTION
### Motivation
- Improve responsive behavior of the main app layout and table scrolling to work better on small screens and touch devices.
- Make admin metrics more accurate by including subscription plan metadata and computing potential MRR and plan counts correctly.
- Provide a mobile-friendly clients list while keeping the full table for larger viewports.

### Description
- Updated `src/components/AppLayout.tsx` to add layout classes to `SidebarProvider`, adjust container min-height (`min-h-[calc(100svh-3rem)]` / `md:min-h-svh`) and enforce `min-w-0` on main and content wrappers for better flex / overflow behavior on small screens.
- Enhanced `src/components/admin/AdminDashboard.tsx` to fetch additional plan fields (`id`, `name`, `slug`, `monthly_price`, `display_order`) and `profiles.selected_plan_slug`, build `plansById` and `plansBySlug`, resolve a profile's selected plan via `getProfilePlan`, and map subscriptions to include resolved plan metadata; changed potential status logic to use a `Set` and renamed a KPI label to `Potencial de MRR`.
- Added plan aggregation logic (`planCounts`) and a new UI card “Negócios por plano” that shows counts, active/trial breakdowns and plan prices.
- Modified query results to return `plans` along with `list` and `profiles` for use in the UI and ensured ordering by `display_order`.
- Adjusted `src/components/ui/table.tsx` wrapper to `className="relative w-full min-w-0 overflow-x-auto overflow-y-hidden overscroll-x-contain [-webkit-overflow-scrolling:touch] [touch-action:pan-x_pan-y]"` to enable horizontal touch scrolling and avoid vertical overflow.
- Converted the clients list in `src/pages/Clients.tsx` to a responsive layout: render a stacked card list for small screens (`md:hidden`) and render the existing table for medium+ screens (`hidden md:block`) with `Table` given a `min-w-[900px]` to preserve column layout.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a202a63c8ac8327880a64d6f77f02a8)