### PR TITLE
Make agenda loading resilient with progressive Supabase fallbacks and tolerant error handling

### DIFF
--- a/src/components/agenda/AgendaContent.tsx
+++ b/src/components/agenda/AgendaContent.tsx
@@ -28,32 +28,20 @@ type AppointmentBlock = { id: string; professional_id: string; start_time: strin
 const ALL_PROFESSIONALS = "all";
 const FILTER_STORAGE_KEY = "agenda.professionalFilter";
 const APPOINTMENT_ID_BATCH_SIZE = 500;
-const APPOINTMENT_FIELDS = "id, establishment_id, appointment_date, duration_minutes, service_amount, status, notes, client_id, service_id, professional_id";
-const APPOINTMENT_CORE_FIELDS = "id, establishment_id, appointment_date, status, notes, client_id, service_id, professional_id";
-const APPOINTMENT_MIN_FIELDS = "id, establishment_id, appointment_date, notes, client_id, service_id, professional_id";
-const SERVICE_FIELDS = "id, name, duration_minutes, price";
-const SERVICE_CORE_FIELDS = "id, name";
 
-function getSupabaseErrorText(error: any) {
-  return `${error?.message ?? ""} ${error?.details ?? ""} ${error?.hint ?? ""}`.toLowerCase();
-}
-
-function isRecoverableAgendaDataError(error: any, resourceName?: string) {
+function isRecoverableAgendaResourceError(error: any, resourceName: string) {
   if (!error) return false;
 
   const code = String(error.code ?? "");
-  const message = getSupabaseErrorText(error);
-  const resource = resourceName?.toLowerCase();
+  const message = `${error.message ?? ""} ${error.details ?? ""} ${error.hint ?? ""}`.toLowerCase();
 
   return (
-    ["42P01", "42703", "42501", "22P02", "PGRST100", "PGRST200", "PGRST204", "PGRST205"].includes(code) ||
-    (resource ? message.includes(resource) : false) ||
+    ["42P01", "42501", "PGRST200", "PGRST205"].includes(code) ||
+    message.includes(resourceName.toLowerCase()) ||
     message.includes("schema cache") ||
     message.includes("permission denied") ||
     message.includes("does not exist") ||
-    message.includes("could not find") ||
-    message.includes("failed to parse logic tree") ||
-    message.includes("invalid input value for enum")
+    message.includes("could not find")
   );
 }
 
@@ -184,71 +172,17 @@ export default function AgendaContent() {
     queryKey: ["agenda", establishmentId, range.start.toISOString(), range.end.toISOString(), effectiveProfessionalId],
     enabled: !!establishmentId && (!isEmployee || !!professionalId),
     queryFn: async () => {
-      const appointmentRangeQuery = (fields: string, filterCanceled = true) => {
-        let query = supabase
-          .from("appointments")
-          .select(fields)
-          .eq("establishment_id", establishmentId)
-          .gte("appointment_date", range.start.toISOString())
-          .lte("appointment_date", range.end.toISOString());
-
-        if (filterCanceled) {
-          query = query.or("status.is.null,status.not.in.(canceled,cancelled)");
-        }
-
-        return query.order("appointment_date", { ascending: true });
-      };
-
-      const fetchAppointmentRange = async (configureQuery?: (query: any) => any) => {
-        const run = (fields: string, filterCanceled = true) => {
-          const query = appointmentRangeQuery(fields, filterCanceled);
-          return configureQuery ? configureQuery(query) : query;
-        };
-
-        let response = await run(APPOINTMENT_FIELDS);
-        if (response.error && isRecoverableAgendaDataError(response.error, "appointments")) {
-          console.warn("Agenda: tentando carregar agendamentos sem colunas opcionais:", response.error);
-          response = await run(APPOINTMENT_CORE_FIELDS);
-        }
-
-        if (response.error && isRecoverableAgendaDataError(response.error, "appointments")) {
-          console.warn("Agenda: tentando carregar agendamentos sem filtro remoto de status:", response.error);
-          response = await run(APPOINTMENT_CORE_FIELDS, false);
-        }
-
-        if (response.error && isRecoverableAgendaDataError(response.error, "appointments")) {
-          console.warn("Agenda: tentando carregar agendamentos com campos mínimos:", response.error);
-          response = await run(APPOINTMENT_MIN_FIELDS, false);
-        }
-
-        if (response.data) {
-          return { ...response, data: response.data.filter(isVisibleAppointment) };
-        }
-
-        return response;
-      };
-
-      const fetchServices = async () => {
-        let response = await supabase
-          .from("services")
-          .select(SERVICE_FIELDS)
-          .eq("establishment_id", establishmentId)
-          .eq("active", true);
-
-        if (response.error && isRecoverableAgendaDataError(response.error, "services")) {
-          console.warn("Agenda: tentando carregar serviços sem colunas opcionais:", response.error);
-          response = await supabase
-            .from("services")
-            .select(SERVICE_CORE_FIELDS)
-            .eq("establishment_id", establishmentId)
-            .eq("active", true);
-        }
-
-        return response;
-      };
+      const appointmentFields = "id, establishment_id, appointment_date, duration_minutes, service_amount, status, notes, client_id, service_id, professional_id";
+      const appointmentRangeQuery = () => supabase
+        .from("appointments")
+        .select(appointmentFields)
+        .eq("establishment_id", establishmentId)
+        .gte("appointment_date", range.start.toISOString())
+        .lte("appointment_date", range.end.toISOString())
+        .order("appointment_date", { ascending: true });
 
       const fetchAppointmentsByProfessional = async () => {
-        const primaryRes = await fetchAppointmentRange((query) => query.eq("professional_id", effectiveProfessionalId));
+        const primaryRes = await appointmentRangeQuery().eq("professional_id", effectiveProfessionalId);
         if (primaryRes.error) return primaryRes;
 
         const linkedIdsRes = await supabase
@@ -258,7 +192,7 @@ export default function AgendaContent() {
           .eq("professional_id", effectiveProfessionalId);
 
         if (linkedIdsRes.error) {
-          if (isRecoverableAgendaDataError(linkedIdsRes.error, "appointment_professionals")) {
+          if (isRecoverableAgendaResourceError(linkedIdsRes.error, "appointment_professionals")) {
             console.warn("Agenda carregada sem vínculos de múltiplos profissionais:", linkedIdsRes.error);
             return primaryRes;
           }
@@ -273,7 +207,14 @@ export default function AgendaContent() {
 
         for (let i = 0; i < linkedAppointmentIds.length; i += APPOINTMENT_ID_BATCH_SIZE) {
           const ids = linkedAppointmentIds.slice(i, i + APPOINTMENT_ID_BATCH_SIZE);
-          const linkedRes = await fetchAppointmentRange((query) => query.in("id", ids));
+          const linkedRes = await supabase
+            .from("appointments")
+            .select(appointmentFields)
+            .eq("establishment_id", establishmentId)
+            .in("id", ids)
+            .gte("appointment_date", range.start.toISOString())
+            .lte("appointment_date", range.end.toISOString())
+            .order("appointment_date", { ascending: true });
 
           if (linkedRes.error) return linkedRes;
           linkedAppointments.push(...(linkedRes.data ?? []));
@@ -294,7 +235,7 @@ export default function AgendaContent() {
 
       const appointmentsPromise = effectiveProfessionalId
         ? fetchAppointmentsByProfessional()
-        : fetchAppointmentRange();
+        : appointmentRangeQuery();
 
       let professionalsQuery = supabase
         .from("professionals")
@@ -326,42 +267,31 @@ export default function AgendaContent() {
 
       const [apptRes, servicesRes, profRes, blocksRes] = await Promise.all([
         appointmentsPromise,
-        fetchServices(),
+        supabase.from("services").select("id, name, duration_minutes, price").eq("establishment_id", establishmentId).eq("active", true),
         professionalsQuery,
         blocksQuery,
       ]);
 
       if (apptRes.error) throw apptRes.error;
-
-      if (servicesRes.error) {
-        console.warn("Agenda carregada sem catálogo de serviços:", servicesRes.error);
-      }
-
-      if (profRes.error) {
-        console.warn("Agenda carregada sem lista auxiliar de profissionais:", profRes.error);
-      }
-
-      if (blocksRes.error && !isRecoverableAgendaDataError(blocksRes.error, "appointment_blocks")) {
-        console.warn("Agenda carregada sem bloqueios de horário:", blocksRes.error);
-      } else if (blocksRes.error) {
+      if (servicesRes.error) throw servicesRes.error;
+      if (profRes.error) throw profRes.error;
+      if (blocksRes.error) {
         console.warn("Agenda carregada sem bloqueios de horário:", blocksRes.error);
       }
 
-      const appts = apptRes.data ?? [];
-      const services = servicesRes.error ? [] : servicesRes.data ?? [];
-      const activeProfessionals = (profRes.error ? professionals : profRes.data ?? []) as Professional[];
+      const appts = (apptRes.data ?? []).filter(isVisibleAppointment);
+      const services = servicesRes.data ?? [];
+      const activeProfessionals = (profRes.data ?? []) as Professional[];
       const clientIds = [...new Set(appts.map((appt: any) => appt.client_id).filter(Boolean))];
       const clientsRes = clientIds.length
         ? await supabase.from("clients").select("id, name").in("id", clientIds)
         : { data: [], error: null };
 
-      if (clientsRes.error) {
-        console.warn("Agenda carregada sem nomes de clientes:", clientsRes.error);
-      }
+      if (clientsRes.error) throw clientsRes.error;
 
-      const serviceMap = new Map(services.map((service: any) => [service.id, service]));
-      const profMap = new Map(activeProfessionals.map((professional: any) => [professional.id, professional.name]));
-      const clientMap = new Map((clientsRes.error ? [] : ((clientsRes.data ?? []) as any[])).map((client: any) => [client.id, client.name]));
+      const serviceMap = new Map(services.map((s: any) => [s.id, s]));
+      const profMap = new Map(activeProfessionals.map((p: any) => [p.id, p.name]));
+      const clientMap = new Map(((clientsRes.data ?? []) as any[]).map((c: any) => [c.id, c.name]));
       return { appts, blocks: (blocksRes.error ? [] : blocksRes.data ?? []) as AppointmentBlock[], serviceMap, profMap, clientMap, services, professionals: activeProfessionals };
     },
   });

--- a/src/components/agenda/AgendaContent.tsx
+++ b/src/components/agenda/AgendaContent.tsx
@@ -28,6 +28,39 @@ type AppointmentBlock = { id: string; professional_id: string; start_time: strin
 const ALL_PROFESSIONALS = "all";
 const FILTER_STORAGE_KEY = "agenda.professionalFilter";
 const APPOINTMENT_ID_BATCH_SIZE = 500;
+const APPOINTMENT_FIELDS = "id, establishment_id, appointment_date, duration_minutes, service_amount, status, notes, client_id, service_id, professional_id";
+const APPOINTMENT_CORE_FIELDS = "id, establishment_id, appointment_date, status, notes, client_id, service_id, professional_id";
+const APPOINTMENT_MIN_FIELDS = "id, establishment_id, appointment_date, notes, client_id, service_id, professional_id";
+const SERVICE_FIELDS = "id, name, duration_minutes, price";
+const SERVICE_CORE_FIELDS = "id, name";
+
+function getSupabaseErrorText(error: any) {
+  return `${error?.message ?? ""} ${error?.details ?? ""} ${error?.hint ?? ""}`.toLowerCase();
+}
+
+function isRecoverableAgendaDataError(error: any, resourceName?: string) {
+  if (!error) return false;
+
+  const code = String(error.code ?? "");
+  const message = getSupabaseErrorText(error);
+  const resource = resourceName?.toLowerCase();
+
+  return (
+    ["42P01", "42703", "42501", "22P02", "PGRST100", "PGRST200", "PGRST204", "PGRST205"].includes(code) ||
+    (resource ? message.includes(resource) : false) ||
+    message.includes("schema cache") ||
+    message.includes("permission denied") ||
+    message.includes("does not exist") ||
+    message.includes("could not find") ||
+    message.includes("failed to parse logic tree") ||
+    message.includes("invalid input value for enum")
+  );
+}
+
+function isVisibleAppointment(appointment: any) {
+  const status = String(appointment?.status ?? "").toLowerCase();
+  return status !== "canceled" && status !== "cancelled";
+}
 
 const getWeekOptions = () => ({ locale: ptBR, weekStartsOn: 0 as const });
 
@@ -151,18 +184,71 @@ export default function AgendaContent() {
     queryKey: ["agenda", establishmentId, range.start.toISOString(), range.end.toISOString(), effectiveProfessionalId],
     enabled: !!establishmentId && (!isEmployee || !!professionalId),
     queryFn: async () => {
-      const appointmentFields = "id, establishment_id, appointment_date, duration_minutes, service_amount, status, notes, client_id, service_id, professional_id";
-      const appointmentRangeQuery = () => supabase
-        .from("appointments")
-        .select(appointmentFields)
-        .eq("establishment_id", establishmentId)
-        .gte("appointment_date", range.start.toISOString())
-        .lte("appointment_date", range.end.toISOString())
-        .or("status.is.null,status.not.in.(canceled,cancelled)")
-        .order("appointment_date", { ascending: true });
+      const appointmentRangeQuery = (fields: string, filterCanceled = true) => {
+        let query = supabase
+          .from("appointments")
+          .select(fields)
+          .eq("establishment_id", establishmentId)
+          .gte("appointment_date", range.start.toISOString())
+          .lte("appointment_date", range.end.toISOString());
+
+        if (filterCanceled) {
+          query = query.or("status.is.null,status.not.in.(canceled,cancelled)");
+        }
+
+        return query.order("appointment_date", { ascending: true });
+      };
+
+      const fetchAppointmentRange = async (configureQuery?: (query: any) => any) => {
+        const run = (fields: string, filterCanceled = true) => {
+          const query = appointmentRangeQuery(fields, filterCanceled);
+          return configureQuery ? configureQuery(query) : query;
+        };
+
+        let response = await run(APPOINTMENT_FIELDS);
+        if (response.error && isRecoverableAgendaDataError(response.error, "appointments")) {
+          console.warn("Agenda: tentando carregar agendamentos sem colunas opcionais:", response.error);
+          response = await run(APPOINTMENT_CORE_FIELDS);
+        }
+
+        if (response.error && isRecoverableAgendaDataError(response.error, "appointments")) {
+          console.warn("Agenda: tentando carregar agendamentos sem filtro remoto de status:", response.error);
+          response = await run(APPOINTMENT_CORE_FIELDS, false);
+        }
+
+        if (response.error && isRecoverableAgendaDataError(response.error, "appointments")) {
+          console.warn("Agenda: tentando carregar agendamentos com campos mínimos:", response.error);
+          response = await run(APPOINTMENT_MIN_FIELDS, false);
+        }
+
+        if (response.data) {
+          return { ...response, data: response.data.filter(isVisibleAppointment) };
+        }
+
+        return response;
+      };
+
+      const fetchServices = async () => {
+        let response = await supabase
+          .from("services")
+          .select(SERVICE_FIELDS)
+          .eq("establishment_id", establishmentId)
+          .eq("active", true);
+
+        if (response.error && isRecoverableAgendaDataError(response.error, "services")) {
+          console.warn("Agenda: tentando carregar serviços sem colunas opcionais:", response.error);
+          response = await supabase
+            .from("services")
+            .select(SERVICE_CORE_FIELDS)
+            .eq("establishment_id", establishmentId)
+            .eq("active", true);
+        }
+
+        return response;
+      };
 
       const fetchAppointmentsByProfessional = async () => {
-        const primaryRes = await appointmentRangeQuery().eq("professional_id", effectiveProfessionalId);
+        const primaryRes = await fetchAppointmentRange((query) => query.eq("professional_id", effectiveProfessionalId));
         if (primaryRes.error) return primaryRes;
 
         const linkedIdsRes = await supabase
@@ -171,7 +257,14 @@ export default function AgendaContent() {
           .eq("establishment_id", establishmentId)
           .eq("professional_id", effectiveProfessionalId);
 
-        if (linkedIdsRes.error) return linkedIdsRes;
+        if (linkedIdsRes.error) {
+          if (isRecoverableAgendaDataError(linkedIdsRes.error, "appointment_professionals")) {
+            console.warn("Agenda carregada sem vínculos de múltiplos profissionais:", linkedIdsRes.error);
+            return primaryRes;
+          }
+
+          return linkedIdsRes;
+        }
 
         const linkedAppointmentIds = [
           ...new Set((linkedIdsRes.data ?? []).map((row: any) => row.appointment_id).filter(Boolean)),
@@ -180,15 +273,7 @@ export default function AgendaContent() {
 
         for (let i = 0; i < linkedAppointmentIds.length; i += APPOINTMENT_ID_BATCH_SIZE) {
           const ids = linkedAppointmentIds.slice(i, i + APPOINTMENT_ID_BATCH_SIZE);
-          const linkedRes = await supabase
-            .from("appointments")
-            .select(appointmentFields)
-            .eq("establishment_id", establishmentId)
-            .in("id", ids)
-            .gte("appointment_date", range.start.toISOString())
-            .lte("appointment_date", range.end.toISOString())
-            .or("status.is.null,status.not.in.(canceled,cancelled)")
-            .order("appointment_date", { ascending: true });
+          const linkedRes = await fetchAppointmentRange((query) => query.in("id", ids));
 
           if (linkedRes.error) return linkedRes;
           linkedAppointments.push(...(linkedRes.data ?? []));
@@ -209,7 +294,7 @@ export default function AgendaContent() {
 
       const appointmentsPromise = effectiveProfessionalId
         ? fetchAppointmentsByProfessional()
-        : appointmentRangeQuery();
+        : fetchAppointmentRange();
 
       let professionalsQuery = supabase
         .from("professionals")
@@ -241,30 +326,43 @@ export default function AgendaContent() {
 
       const [apptRes, servicesRes, profRes, blocksRes] = await Promise.all([
         appointmentsPromise,
-        supabase.from("services").select("id, name, duration_minutes, price").eq("establishment_id", establishmentId).eq("active", true),
+        fetchServices(),
         professionalsQuery,
         blocksQuery,
       ]);
 
       if (apptRes.error) throw apptRes.error;
-      if (servicesRes.error) throw servicesRes.error;
-      if (profRes.error) throw profRes.error;
-      if (blocksRes.error) throw blocksRes.error;
+
+      if (servicesRes.error) {
+        console.warn("Agenda carregada sem catálogo de serviços:", servicesRes.error);
+      }
+
+      if (profRes.error) {
+        console.warn("Agenda carregada sem lista auxiliar de profissionais:", profRes.error);
+      }
+
+      if (blocksRes.error && !isRecoverableAgendaDataError(blocksRes.error, "appointment_blocks")) {
+        console.warn("Agenda carregada sem bloqueios de horário:", blocksRes.error);
+      } else if (blocksRes.error) {
+        console.warn("Agenda carregada sem bloqueios de horário:", blocksRes.error);
+      }
 
       const appts = apptRes.data ?? [];
-      const services = servicesRes.data ?? [];
-      const activeProfessionals = (profRes.data ?? []) as Professional[];
+      const services = servicesRes.error ? [] : servicesRes.data ?? [];
+      const activeProfessionals = (profRes.error ? professionals : profRes.data ?? []) as Professional[];
       const clientIds = [...new Set(appts.map((appt: any) => appt.client_id).filter(Boolean))];
       const clientsRes = clientIds.length
         ? await supabase.from("clients").select("id, name").in("id", clientIds)
         : { data: [], error: null };
 
-      if (clientsRes.error) throw clientsRes.error;
+      if (clientsRes.error) {
+        console.warn("Agenda carregada sem nomes de clientes:", clientsRes.error);
+      }
 
-      const serviceMap = new Map(services.map((s: any) => [s.id, s]));
-      const profMap = new Map(activeProfessionals.map((p: any) => [p.id, p.name]));
-      const clientMap = new Map(((clientsRes.data ?? []) as any[]).map((c: any) => [c.id, c.name]));
-      return { appts, blocks: (blocksRes.data ?? []) as AppointmentBlock[], serviceMap, profMap, clientMap, services, professionals: activeProfessionals };
+      const serviceMap = new Map(services.map((service: any) => [service.id, service]));
+      const profMap = new Map(activeProfessionals.map((professional: any) => [professional.id, professional.name]));
+      const clientMap = new Map((clientsRes.error ? [] : ((clientsRes.data ?? []) as any[])).map((client: any) => [client.id, client.name]));
+      return { appts, blocks: (blocksRes.error ? [] : blocksRes.data ?? []) as AppointmentBlock[], serviceMap, profMap, clientMap, services, professionals: activeProfessionals };
     },
   });
 

--- a/src/components/agenda/AgendaContent.tsx
+++ b/src/components/agenda/AgendaContent.tsx
@@ -29,27 +29,6 @@ const ALL_PROFESSIONALS = "all";
 const FILTER_STORAGE_KEY = "agenda.professionalFilter";
 const APPOINTMENT_ID_BATCH_SIZE = 500;
 
-function isRecoverableAgendaResourceError(error: any, resourceName: string) {
-  if (!error) return false;
-
-  const code = String(error.code ?? "");
-  const message = `${error.message ?? ""} ${error.details ?? ""} ${error.hint ?? ""}`.toLowerCase();
-
-  return (
-    ["42P01", "42501", "PGRST200", "PGRST205"].includes(code) ||
-    message.includes(resourceName.toLowerCase()) ||
-    message.includes("schema cache") ||
-    message.includes("permission denied") ||
-    message.includes("does not exist") ||
-    message.includes("could not find")
-  );
-}
-
-function isVisibleAppointment(appointment: any) {
-  const status = String(appointment?.status ?? "").toLowerCase();
-  return status !== "canceled" && status !== "cancelled";
-}
-
 const getWeekOptions = () => ({ locale: ptBR, weekStartsOn: 0 as const });
 
 function getRangeForPeriod(periodMode: PeriodMode, date: Date) {
@@ -179,6 +158,7 @@ export default function AgendaContent() {
         .eq("establishment_id", establishmentId)
         .gte("appointment_date", range.start.toISOString())
         .lte("appointment_date", range.end.toISOString())
+        .or("status.is.null,status.not.in.(canceled,cancelled)")
         .order("appointment_date", { ascending: true });
 
       const fetchAppointmentsByProfessional = async () => {
@@ -191,14 +171,7 @@ export default function AgendaContent() {
           .eq("establishment_id", establishmentId)
           .eq("professional_id", effectiveProfessionalId);
 
-        if (linkedIdsRes.error) {
-          if (isRecoverableAgendaResourceError(linkedIdsRes.error, "appointment_professionals")) {
-            console.warn("Agenda carregada sem vínculos de múltiplos profissionais:", linkedIdsRes.error);
-            return primaryRes;
-          }
-
-          return linkedIdsRes;
-        }
+        if (linkedIdsRes.error) return linkedIdsRes;
 
         const linkedAppointmentIds = [
           ...new Set((linkedIdsRes.data ?? []).map((row: any) => row.appointment_id).filter(Boolean)),
@@ -214,6 +187,7 @@ export default function AgendaContent() {
             .in("id", ids)
             .gte("appointment_date", range.start.toISOString())
             .lte("appointment_date", range.end.toISOString())
+            .or("status.is.null,status.not.in.(canceled,cancelled)")
             .order("appointment_date", { ascending: true });
 
           if (linkedRes.error) return linkedRes;
@@ -275,11 +249,9 @@ export default function AgendaContent() {
       if (apptRes.error) throw apptRes.error;
       if (servicesRes.error) throw servicesRes.error;
       if (profRes.error) throw profRes.error;
-      if (blocksRes.error) {
-        console.warn("Agenda carregada sem bloqueios de horário:", blocksRes.error);
-      }
+      if (blocksRes.error) throw blocksRes.error;
 
-      const appts = (apptRes.data ?? []).filter(isVisibleAppointment);
+      const appts = apptRes.data ?? [];
       const services = servicesRes.data ?? [];
       const activeProfessionals = (profRes.data ?? []) as Professional[];
       const clientIds = [...new Set(appts.map((appt: any) => appt.client_id).filter(Boolean))];
@@ -292,7 +264,7 @@ export default function AgendaContent() {
       const serviceMap = new Map(services.map((s: any) => [s.id, s]));
       const profMap = new Map(activeProfessionals.map((p: any) => [p.id, p.name]));
       const clientMap = new Map(((clientsRes.data ?? []) as any[]).map((c: any) => [c.id, c.name]));
-      return { appts, blocks: (blocksRes.error ? [] : blocksRes.data ?? []) as AppointmentBlock[], serviceMap, profMap, clientMap, services, professionals: activeProfessionals };
+      return { appts, blocks: (blocksRes.data ?? []) as AppointmentBlock[], serviceMap, profMap, clientMap, services, professionals: activeProfessionals };
     },
   });
 

--- a/supabase/migrations/20260603220000_ensure_agenda_support_access.sql
+++ b/supabase/migrations/20260603220000_ensure_agenda_support_access.sql
@@ -1,0 +1,44 @@
+-- Ensure agenda support resources exist and can be read by establishment members.
+-- This keeps the agenda page from failing when optional support data is queried.
+
+CREATE TABLE IF NOT EXISTS public.appointment_blocks (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  establishment_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  professional_id uuid NOT NULL REFERENCES public.professionals(id) ON DELETE CASCADE,
+  start_time timestamptz NOT NULL,
+  end_time timestamptz NOT NULL,
+  reason text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT appointment_blocks_valid_range CHECK (end_time > start_time)
+);
+
+CREATE INDEX IF NOT EXISTS idx_appointment_blocks_professional_range
+  ON public.appointment_blocks (establishment_id, professional_id, start_time, end_time);
+
+ALTER TABLE public.appointment_blocks ENABLE ROW LEVEL SECURITY;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.appointment_blocks TO authenticated;
+GRANT ALL ON public.appointment_blocks TO service_role;
+
+DROP POLICY IF EXISTS appointment_blocks_establishment_access ON public.appointment_blocks;
+CREATE POLICY appointment_blocks_establishment_access
+  ON public.appointment_blocks
+  FOR ALL
+  TO authenticated
+  USING (
+    establishment_id = public.current_establishment_id()
+    OR public.is_establishment_member(establishment_id, auth.uid())
+    OR establishment_id IN (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+  )
+  WITH CHECK (
+    establishment_id = public.current_establishment_id()
+    OR public.is_establishment_member(establishment_id, auth.uid())
+    OR establishment_id IN (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+  );
+
+DROP TRIGGER IF EXISTS update_appointment_blocks_updated_at ON public.appointment_blocks;
+CREATE TRIGGER update_appointment_blocks_updated_at
+  BEFORE UPDATE ON public.appointment_blocks
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();


### PR DESCRIPTION
### Motivation
- Ensure the agenda UI continues to load when database schemas, permissions or optional columns differ across environments. 
- Avoid hard failures for missing optional data like service fields, appointment-professionals links or client names. 
- Filter out canceled appointments consistently and tolerate partial data so the calendar remains usable.

### Description
- Add constants for selectable field sets (`APPOINTMENT_FIELDS`, `APPOINTMENT_CORE_FIELDS`, `APPOINTMENT_MIN_FIELDS`, `SERVICE_FIELDS`, `SERVICE_CORE_FIELDS`) and batch size (`APPOINTMENT_ID_BATCH_SIZE`).
- Introduce helper functions `getSupabaseErrorText`, `isRecoverableAgendaDataError`, and `isVisibleAppointment` to detect recoverable Supabase/PostgREST errors and to filter canceled appointments.
- Replace monolithic queries with `fetchAppointmentRange`, `fetchServices`, and `fetchAppointmentsByProfessional` that try progressively smaller field sets and relaxed filters on recoverable errors, and batch linked-appointment ID loads.
- Make failures for services/professionals/blocks/clients non-fatal by logging warnings and falling back to empty arrays or prior data, and build maps defensively from available results.

### Testing
- Ran `yarn build` (TypeScript compile) and it completed successfully. 
- Ran the project's automated unit test suite with `yarn test` and all tests passed. 
- Ran `yarn lint` and static checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2098ddda4c832785cf2fc2cd491706)