### PR TITLE
Permitir horário de funcionamento configurável por salão

### DIFF
--- a/src/components/agenda/AgendaCalendar.tsx
+++ b/src/components/agenda/AgendaCalendar.tsx
@@ -4,6 +4,7 @@ import { format, parse, startOfWeek, getDay } from "date-fns";
 import { ptBR } from "date-fns/locale";
 import "react-big-calendar/lib/css/react-big-calendar.css";
 import { STATUS_COLORS, STATUS_LABELS, normalizeStatus } from "@/lib/appointmentStatus";
+import { buildBusinessTimeBoundary, DEFAULT_CLOSING_TIME, DEFAULT_OPENING_TIME } from "@/lib/businessHours";
 
 const locales = { "pt-BR": ptBR };
 const localizer = dateFnsLocalizer({ format, parse, startOfWeek: (d: Date) => startOfWeek(d, { locale: ptBR }), getDay, locales });
@@ -50,19 +51,6 @@ interface Props {
   onRangeChange?: (range: { start: Date; end: Date }) => void;
 }
 
-function buildTimeBoundary(time: string | undefined, fallbackHour: number, fallbackMinute: number) {
-  const d = new Date();
-  let h = fallbackHour;
-  let m = fallbackMinute;
-  if (time && /^\d{1,2}:\d{2}/.test(time)) {
-    const [hh, mm] = time.split(":").map(Number);
-    if (!isNaN(hh)) h = hh;
-    if (!isNaN(mm)) m = mm;
-  }
-  d.setHours(h, m, 0, 0);
-  return d;
-}
-
 export function AgendaCalendar({
   events,
   view,
@@ -76,8 +64,8 @@ export function AgendaCalendar({
   onSelectEvent,
   onRangeChange,
 }: Props) {
-  const minTime = useMemo(() => buildTimeBoundary(openTime, 8, 0), [openTime]);
-  const maxTime = useMemo(() => buildTimeBoundary(closeTime, 19, 0), [closeTime]);
+  const minTime = useMemo(() => buildBusinessTimeBoundary(openTime, DEFAULT_OPENING_TIME), [openTime]);
+  const maxTime = useMemo(() => buildBusinessTimeBoundary(closeTime, DEFAULT_CLOSING_TIME), [closeTime]);
 
   const eventPropGetter = useMemo(
     () => (event: AgendaEvent) => {

--- a/src/components/agenda/AgendaContent.tsx
+++ b/src/components/agenda/AgendaContent.tsx
@@ -20,6 +20,7 @@ import { AppointmentDetailsDialog } from "@/components/agenda/AppointmentDetails
 import { AppointmentBlockDialog } from "@/components/agenda/AppointmentBlockDialog";
 import ImportAppointmentsDialog from "@/components/agenda/ImportAppointmentsDialog";
 import { STATUS_LABELS, STATUS_VARIANTS, STATUS_OPTIONS, normalizeStatus } from "@/lib/appointmentStatus";
+import { BUSINESS_HOURS_SELECT, DEFAULT_CLOSING_TIME, DEFAULT_OPENING_TIME, normalizeTimeValue } from "@/lib/businessHours";
 
 type PeriodMode = "day" | "week" | "month" | "custom";
 type Professional = { id: string; name: string };
@@ -162,6 +163,23 @@ export default function AgendaContent() {
       setSelectedProfessionalId(ALL_PROFESSIONALS);
     }
   }, [isEmployee, professionals, selectedProfessionalId]);
+
+  const { data: businessHours = { open: DEFAULT_OPENING_TIME, close: DEFAULT_CLOSING_TIME } } = useQuery({
+    queryKey: ["business-hours", establishmentId],
+    enabled: !!establishmentId,
+    queryFn: async () => {
+      const { data, error } = await (supabase as any)
+        .from("settings")
+        .select(BUSINESS_HOURS_SELECT)
+        .eq("establishment_id", establishmentId)
+        .maybeSingle();
+      if (error) throw error;
+      return {
+        open: normalizeTimeValue(data?.opening_time, DEFAULT_OPENING_TIME),
+        close: normalizeTimeValue(data?.closing_time, DEFAULT_CLOSING_TIME),
+      };
+    },
+  });
 
   const { data, isLoading, isFetching, error } = useQuery({
     queryKey: ["agenda", establishmentId, range.start.toISOString(), range.end.toISOString(), effectiveProfessionalId],
@@ -485,6 +503,8 @@ export default function AgendaContent() {
           view={calendarView}
           date={calendarDate}
           agendaLength={Math.max(1, Math.round((range.end.getTime() - range.start.getTime()) / 86_400_000) + 1)}
+          openTime={businessHours.open}
+          closeTime={businessHours.close}
           onViewChange={handleCalendarViewChange}
           onNavigate={setCalendarDate}
           onSelectSlot={handleSlot}

--- a/src/components/agenda/ResilientAgendaContent.tsx
+++ b/src/components/agenda/ResilientAgendaContent.tsx
@@ -20,6 +20,7 @@ import { AppointmentDetailsDialog } from "@/components/agenda/AppointmentDetails
 import { AppointmentBlockDialog } from "@/components/agenda/AppointmentBlockDialog";
 import ImportAppointmentsDialog from "@/components/agenda/ImportAppointmentsDialog";
 import { STATUS_LABELS, STATUS_VARIANTS, STATUS_OPTIONS, normalizeStatus } from "@/lib/appointmentStatus";
+import { BUSINESS_HOURS_SELECT, DEFAULT_CLOSING_TIME, DEFAULT_OPENING_TIME, normalizeTimeValue } from "@/lib/businessHours";
 
 type PeriodMode = "day" | "week" | "month" | "custom";
 type Professional = { id: string; name: string };
@@ -166,6 +167,23 @@ export default function ResilientAgendaContent() {
       setSelectedProfessionalId(ALL_PROFESSIONALS);
     }
   }, [isEmployee, professionals, selectedProfessionalId]);
+
+  const { data: businessHours = { open: DEFAULT_OPENING_TIME, close: DEFAULT_CLOSING_TIME } } = useQuery({
+    queryKey: ["business-hours", establishmentId],
+    enabled: !!establishmentId,
+    queryFn: async () => {
+      const { data, error } = await (supabase as any)
+        .from("settings")
+        .select(BUSINESS_HOURS_SELECT)
+        .eq("establishment_id", establishmentId)
+        .maybeSingle();
+      if (error) throw error;
+      return {
+        open: normalizeTimeValue(data?.opening_time, DEFAULT_OPENING_TIME),
+        close: normalizeTimeValue(data?.closing_time, DEFAULT_CLOSING_TIME),
+      };
+    },
+  });
 
   const { data, isLoading, isFetching } = useQuery({
     queryKey: ["agenda", establishmentId, range.start.toISOString(), range.end.toISOString(), effectiveProfessionalId],
@@ -503,6 +521,8 @@ export default function ResilientAgendaContent() {
           onNavigate={setCalendarDate}
           onSelectSlot={handleSlot}
           onSelectEvent={handleEventClick}
+          openTime={businessHours.open}
+          closeTime={businessHours.close}
           onRangeChange={handleCalendarRangeChange}
         />
       ) : (

--- a/src/components/agenda/StableAgendaContent.tsx
+++ b/src/components/agenda/StableAgendaContent.tsx
@@ -20,6 +20,7 @@ import { AppointmentDetailsDialog } from "@/components/agenda/AppointmentDetails
 import { AppointmentBlockDialog } from "@/components/agenda/AppointmentBlockDialog";
 import ImportAppointmentsDialog from "@/components/agenda/ImportAppointmentsDialog";
 import { STATUS_LABELS, STATUS_VARIANTS, STATUS_OPTIONS, normalizeStatus } from "@/lib/appointmentStatus";
+import { BUSINESS_HOURS_SELECT, DEFAULT_CLOSING_TIME, DEFAULT_OPENING_TIME, normalizeTimeValue } from "@/lib/businessHours";
 
 type PeriodMode = "day" | "week" | "month" | "custom";
 type Professional = { id: string; name: string };
@@ -162,18 +163,18 @@ export default function StableAgendaContent() {
     },
   });
 
-  const { data: businessHours = { open: "08:00", close: "19:00" } } = useQuery({
+  const { data: businessHours = { open: DEFAULT_OPENING_TIME, close: DEFAULT_CLOSING_TIME } } = useQuery({
     queryKey: ["business-hours", establishmentId],
     enabled: !!establishmentId,
     queryFn: async () => {
       const { data } = await (supabase as any)
         .from("settings")
-        .select("business_open_time, business_close_time")
+        .select(BUSINESS_HOURS_SELECT)
         .eq("establishment_id", establishmentId)
         .maybeSingle();
       return {
-        open: String(data?.business_open_time ?? "08:00").slice(0, 5),
-        close: String(data?.business_close_time ?? "19:00").slice(0, 5),
+        open: normalizeTimeValue(data?.opening_time, DEFAULT_OPENING_TIME),
+        close: normalizeTimeValue(data?.closing_time, DEFAULT_CLOSING_TIME),
       };
     },
   });

--- a/src/components/settings/GeneralSettingsForm.tsx
+++ b/src/components/settings/GeneralSettingsForm.tsx
@@ -4,40 +4,43 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { supabase } from "@/integrations/supabase/client";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { areBusinessHoursValid, BUSINESS_HOURS_SELECT, DEFAULT_CLOSING_TIME, DEFAULT_OPENING_TIME, normalizeTimeValue } from "@/lib/businessHours";
 
 interface GeneralSettingsFormProps {
   establishmentId: string;
 }
 
 export function GeneralSettingsForm({ establishmentId }: GeneralSettingsFormProps) {
+  const queryClient = useQueryClient();
+
   const { data, isLoading, refetch } = useQuery({
     queryKey: ["settings", establishmentId],
     queryFn: async () => {
       const [settingsRes, profileRes] = await Promise.all([
-        (supabase as any).from("settings").select("id, inactive_days_threshold, business_open_time, business_close_time").eq("establishment_id", establishmentId).maybeSingle(),
+        (supabase as any).from("settings").select(BUSINESS_HOURS_SELECT).eq("establishment_id", establishmentId).maybeSingle(),
         supabase.from("profiles").select("accepting_bookings").eq("id", establishmentId).maybeSingle(),
       ]);
       if (settingsRes.error) throw settingsRes.error;
       if (profileRes.error) throw profileRes.error;
       return {
-        settings: settingsRes.data as { id: string; inactive_days_threshold: number; business_open_time: string | null; business_close_time: string | null } | null,
+        settings: settingsRes.data as { id: string; inactive_days_threshold: number; opening_time: string | null; closing_time: string | null } | null,
         accepting_bookings: (profileRes.data as any)?.accepting_bookings ?? true,
       };
     },
   });
 
   const [threshold, setThreshold] = useState<number>(20);
-  const [openTime, setOpenTime] = useState<string>("08:00");
-  const [closeTime, setCloseTime] = useState<string>("19:00");
+  const [openTime, setOpenTime] = useState<string>(DEFAULT_OPENING_TIME);
+  const [closeTime, setCloseTime] = useState<string>(DEFAULT_CLOSING_TIME);
   const [accepting, setAccepting] = useState<boolean>(true);
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     if (data?.settings?.inactive_days_threshold != null) setThreshold(Number(data.settings.inactive_days_threshold));
-    if (data?.settings?.business_open_time) setOpenTime(String(data.settings.business_open_time).slice(0, 5));
-    if (data?.settings?.business_close_time) setCloseTime(String(data.settings.business_close_time).slice(0, 5));
+    if (data?.settings?.opening_time) setOpenTime(normalizeTimeValue(data.settings.opening_time, DEFAULT_OPENING_TIME));
+    if (data?.settings?.closing_time) setCloseTime(normalizeTimeValue(data.settings.closing_time, DEFAULT_CLOSING_TIME));
     if (data) setAccepting(data.accepting_bookings);
   }, [data]);
 
@@ -54,12 +57,17 @@ export function GeneralSettingsForm({ establishmentId }: GeneralSettingsFormProp
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!areBusinessHoursValid(openTime, closeTime)) {
+      toast.error("Informe horários válidos no formato HH:mm, com abertura menor que fechamento.");
+      return;
+    }
+
     setSaving(true);
     try {
       const payload = {
         inactive_days_threshold: threshold,
-        business_open_time: openTime,
-        business_close_time: closeTime,
+        opening_time: openTime,
+        closing_time: closeTime,
       };
       if (data?.settings?.id) {
         const { error } = await (supabase as any)
@@ -74,7 +82,11 @@ export function GeneralSettingsForm({ establishmentId }: GeneralSettingsFormProp
         if (error) throw error;
       }
       toast.success("Preferências salvas!");
-      await refetch();
+      await Promise.all([
+        refetch(),
+        queryClient.invalidateQueries({ queryKey: ["agenda"] }),
+        queryClient.invalidateQueries({ queryKey: ["business-hours"] }),
+      ]);
     } catch (err: any) {
       toast.error(err?.message ?? "Não foi possível salvar as preferências.");
     } finally {

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -927,28 +927,34 @@ export type Database = {
         Row: {
           business_close_time: string
           business_open_time: string
+          closing_time: string
           created_at: string
           establishment_id: string
           id: string
           inactive_days_threshold: number | null
+          opening_time: string
           updated_at: string
         }
         Insert: {
           business_close_time?: string
           business_open_time?: string
+          closing_time?: string
           created_at?: string
           establishment_id: string
           id?: string
           inactive_days_threshold?: number | null
+          opening_time?: string
           updated_at?: string
         }
         Update: {
           business_close_time?: string
           business_open_time?: string
+          closing_time?: string
           created_at?: string
           establishment_id?: string
           id?: string
           inactive_days_threshold?: number | null
+          opening_time?: string
           updated_at?: string
         }
         Relationships: [

--- a/src/lib/businessHours.ts
+++ b/src/lib/businessHours.ts
@@ -1,0 +1,55 @@
+export const BUSINESS_HOURS_SELECT = "id, inactive_days_threshold, opening_time, closing_time";
+export const DEFAULT_OPENING_TIME = "08:00";
+export const DEFAULT_CLOSING_TIME = "19:00";
+
+const TIME_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+export type BusinessHours = {
+  openingTime: string;
+  closingTime: string;
+};
+
+export function normalizeTimeValue(value: string | null | undefined, fallback: string): string {
+  const candidate = String(value ?? "").slice(0, 5);
+  return isValidTimeValue(candidate) ? candidate : fallback;
+}
+
+export function isValidTimeValue(value: string): boolean {
+  return TIME_PATTERN.test(value);
+}
+
+export function timeToMinutes(value: string): number {
+  const [hours, minutes] = value.split(":").map(Number);
+  return hours * 60 + minutes;
+}
+
+export function areBusinessHoursValid(openingTime: string, closingTime: string): boolean {
+  return isValidTimeValue(openingTime) && isValidTimeValue(closingTime) && timeToMinutes(openingTime) < timeToMinutes(closingTime);
+}
+
+export function buildDateAtTime(baseDate: Date, value: string): Date {
+  const [hours, minutes] = value.split(":").map(Number);
+  const date = new Date(baseDate);
+  date.setHours(hours, minutes, 0, 0);
+  return date;
+}
+
+export function buildBusinessTimeBoundary(value: string | undefined, fallback: string): Date {
+  return buildDateAtTime(new Date(), normalizeTimeValue(value, fallback));
+}
+
+export function generateBusinessSlots(date: Date, openingTime: string, closingTime: string, durationMinutes = 30, stepMinutes = 30): Date[] {
+  if (!areBusinessHoursValid(openingTime, closingTime)) return [];
+
+  const start = buildDateAtTime(date, openingTime);
+  const end = buildDateAtTime(date, closingTime);
+  const slots: Date[] = [];
+  let current = start;
+
+  while (current.getTime() + durationMinutes * 60_000 <= end.getTime()) {
+    slots.push(new Date(current));
+    current = new Date(current.getTime() + stepMinutes * 60_000);
+  }
+
+  return slots;
+}

--- a/src/pages/PublicBooking.tsx
+++ b/src/pages/PublicBooking.tsx
@@ -4,14 +4,14 @@ import { supabase } from "@/integrations/supabase/client";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Calendar } from "@/components/ui/calendar";
-import { Calendar as CalendarIcon, ChevronDown } from "lucide-react";
+import { Calendar as CalendarIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { format, addMinutes, setHours, setMinutes, isSameDay } from "date-fns";
+import { format, isSameDay } from "date-fns";
 import { useToast } from "@/hooks/use-toast";
+import { DEFAULT_CLOSING_TIME, DEFAULT_OPENING_TIME, generateBusinessSlots, normalizeTimeValue } from "@/lib/businessHours";
 
 interface Service { id: string; name: string; price: number; duration: number }
 interface Professional { id: string; name: string }
@@ -21,6 +21,7 @@ export default function PublicBooking() {
   const [resolvedId, setResolvedId] = useState<string | null>(null);
   const [salonName, setSalonName] = useState<string>("");
   const [acceptingBookings, setAcceptingBookings] = useState<boolean>(true);
+  const [businessHours, setBusinessHours] = useState({ openingTime: DEFAULT_OPENING_TIME, closingTime: DEFAULT_CLOSING_TIME });
   const [lookupState, setLookupState] = useState<"loading" | "ok" | "not_found">("loading");
   const [services, setServices] = useState<Service[]>([]);
   const [professionals, setProfessionals] = useState<Professional[]>([]);
@@ -60,6 +61,10 @@ export default function PublicBooking() {
         setResolvedId(salon.id);
         setSalonName(salon.business_name || "");
         setAcceptingBookings(salon.accepting_bookings !== false);
+        setBusinessHours({
+          openingTime: normalizeTimeValue(salon.opening_time, DEFAULT_OPENING_TIME),
+          closingTime: normalizeTimeValue(salon.closing_time, DEFAULT_CLOSING_TIME),
+        });
         setLookupState("ok");
         document.title = `${salon.business_name || "Agendar atendimento"} | Beauty Core`;
       } else if (establishmentId) {
@@ -72,6 +77,10 @@ export default function PublicBooking() {
         setResolvedId(salon.id);
         setSalonName(salon.business_name || "");
         setAcceptingBookings(salon.accepting_bookings !== false);
+        setBusinessHours({
+          openingTime: normalizeTimeValue(salon.opening_time, DEFAULT_OPENING_TIME),
+          closingTime: normalizeTimeValue(salon.closing_time, DEFAULT_CLOSING_TIME),
+        });
         setLookupState("ok");
       } else {
         setLookupState("not_found");
@@ -126,16 +135,8 @@ export default function PublicBooking() {
 
   const slots = useMemo(() => {
     if (!date) return [] as Date[];
-    const start = setMinutes(setHours(new Date(date), 9), 0); // 09:00
-    const end = setMinutes(setHours(new Date(date), 18), 0); // 18:00
-    const out: Date[] = [];
-    let cur = start;
-    while (cur <= end) {
-      out.push(new Date(cur));
-      cur = addMinutes(cur, 30);
-    }
-    return out;
-  }, [date]);
+    return generateBusinessSlots(date, businessHours.openingTime, businessHours.closingTime, Math.max(totalDuration, 30));
+  }, [businessHours.closingTime, businessHours.openingTime, date, totalDuration]);
 
   const isBooked = (d: Date) => {
     // compare by hour/minute on same day
@@ -150,7 +151,8 @@ export default function PublicBooking() {
   const handleSubmit = async () => {
     if (!canSubmit || !date) return;
     const [hh, mm] = slot.split(":").map(Number);
-    const startTime = setMinutes(setHours(new Date(date), hh), mm);
+    const startTime = new Date(date);
+    startTime.setHours(hh, mm, 0, 0);
     const { data, error } = await supabase.rpc("create_public_booking", {
       establishment: resolvedId!,
       client_name: clientName,

--- a/src/pages/components/AgendaContent.tsx
+++ b/src/pages/components/AgendaContent.tsx
@@ -19,6 +19,7 @@ import { AppointmentFormDialog } from "@/components/agenda/AppointmentFormDialog
 import { AppointmentDetailsDialog } from "@/components/agenda/AppointmentDetailsDialog";
 import ImportAppointmentsDialog from "@/components/agenda/ImportAppointmentsDialog";
 import { STATUS_LABELS, STATUS_VARIANTS, STATUS_OPTIONS, normalizeStatus } from "@/lib/appointmentStatus";
+import { BUSINESS_HOURS_SELECT, DEFAULT_CLOSING_TIME, DEFAULT_OPENING_TIME, normalizeTimeValue } from "@/lib/businessHours";
 
 type PeriodMode = "day" | "week" | "month" | "custom";
 type Professional = { id: string; name: string };
@@ -141,6 +142,23 @@ export default function AgendaContent() {
       setSelectedProfessionalId(ALL_PROFESSIONALS);
     }
   }, [isEmployee, professionals, selectedProfessionalId]);
+
+  const { data: businessHours = { open: DEFAULT_OPENING_TIME, close: DEFAULT_CLOSING_TIME } } = useQuery({
+    queryKey: ["business-hours", establishmentId],
+    enabled: !!establishmentId,
+    queryFn: async () => {
+      const { data, error } = await (supabase as any)
+        .from("settings")
+        .select(BUSINESS_HOURS_SELECT)
+        .eq("establishment_id", establishmentId)
+        .maybeSingle();
+      if (error) throw error;
+      return {
+        open: normalizeTimeValue(data?.opening_time, DEFAULT_OPENING_TIME),
+        close: normalizeTimeValue(data?.closing_time, DEFAULT_CLOSING_TIME),
+      };
+    },
+  });
 
   const { data, isLoading, isFetching, error } = useQuery({
     queryKey: ["agenda", establishmentId, range.start.toISOString(), range.end.toISOString(), effectiveProfessionalId],
@@ -386,6 +404,8 @@ export default function AgendaContent() {
           view={calendarView}
           date={calendarDate}
           agendaLength={Math.max(1, Math.round((range.end.getTime() - range.start.getTime()) / 86_400_000) + 1)}
+          openTime={businessHours.open}
+          closeTime={businessHours.close}
           onViewChange={handleCalendarViewChange}
           onNavigate={setCalendarDate}
           onSelectSlot={handleSlot}

--- a/supabase/migrations/20260605163000_add_configurable_business_hours.sql
+++ b/supabase/migrations/20260605163000_add_configurable_business_hours.sql
@@ -1,0 +1,93 @@
+-- Store configurable business hours per establishment and expose them through public booking RPCs.
+ALTER TABLE public.settings
+  ADD COLUMN IF NOT EXISTS opening_time time without time zone,
+  ADD COLUMN IF NOT EXISTS closing_time time without time zone;
+
+UPDATE public.settings
+SET
+  opening_time = COALESCE(opening_time, business_open_time, '08:00'::time),
+  closing_time = COALESCE(closing_time, business_close_time, '19:00'::time)
+WHERE opening_time IS NULL OR closing_time IS NULL;
+
+ALTER TABLE public.settings
+  ALTER COLUMN opening_time SET NOT NULL,
+  ALTER COLUMN opening_time SET DEFAULT '08:00'::time,
+  ALTER COLUMN closing_time SET NOT NULL,
+  ALTER COLUMN closing_time SET DEFAULT '19:00'::time;
+
+ALTER TABLE public.settings
+  DROP CONSTRAINT IF EXISTS settings_business_hours_order_check;
+
+ALTER TABLE public.settings
+  ADD CONSTRAINT settings_business_hours_order_check CHECK (opening_time < closing_time);
+
+CREATE OR REPLACE FUNCTION public.sync_legacy_business_hours()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'public'
+AS $$
+BEGIN
+  NEW.business_open_time := NEW.opening_time;
+  NEW.business_close_time := NEW.closing_time;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_sync_legacy_business_hours ON public.settings;
+CREATE TRIGGER trg_sync_legacy_business_hours
+BEFORE INSERT OR UPDATE OF opening_time, closing_time ON public.settings
+FOR EACH ROW
+EXECUTE FUNCTION public.sync_legacy_business_hours();
+
+CREATE OR REPLACE FUNCTION public.get_public_salon_by_slug(p_slug text)
+RETURNS json
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE result json;
+BEGIN
+  SELECT json_build_object(
+    'id', p.id,
+    'business_name', p.business_name,
+    'city', p.city,
+    'accepting_bookings', p.accepting_bookings,
+    'opening_time', to_char(COALESCE(s.opening_time, '08:00'::time), 'HH24:MI'),
+    'closing_time', to_char(COALESCE(s.closing_time, '19:00'::time), 'HH24:MI')
+  )
+  INTO result
+  FROM public.profiles p
+  LEFT JOIN public.settings s ON s.establishment_id = p.id
+  WHERE p.slug = p_slug
+  LIMIT 1;
+  RETURN result;
+END; $$;
+
+CREATE OR REPLACE FUNCTION public.get_public_salon_by_id(p_id uuid)
+RETURNS json
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE result json;
+BEGIN
+  SELECT json_build_object(
+    'id', p.id,
+    'business_name', p.business_name,
+    'city', p.city,
+    'accepting_bookings', p.accepting_bookings,
+    'opening_time', to_char(COALESCE(s.opening_time, '08:00'::time), 'HH24:MI'),
+    'closing_time', to_char(COALESCE(s.closing_time, '19:00'::time), 'HH24:MI')
+  )
+  INTO result
+  FROM public.profiles p
+  LEFT JOIN public.settings s ON s.establishment_id = p.id
+  WHERE p.id = p_id
+  LIMIT 1;
+  RETURN result;
+END; $$;
+
+GRANT EXECUTE ON FUNCTION public.get_public_salon_by_slug(text) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_public_salon_by_id(uuid) TO anon, authenticated;


### PR DESCRIPTION
### Motivation
- Remover o comportamento engessado de horários e permitir que cada salão defina livremente `opening_time` e `closing_time` (HH:mm) por estabelecimento. 
- Garantir que a agenda pública e interna respeitem o intervalo configurado e que bookings só ocorram dentro do funcionamento do salão.

### Description
- Banco de dados: adiciona migração que cria as colunas `opening_time` e `closing_time` em `public.settings`, popula valores legados, aplica `NOT NULL`/`DEFAULT` e adiciona a constraint `CHECK (opening_time < closing_time)` e trigger para sincronizar colunas legadas; as RPCs públicas foram expostas para retornar os horários. (`supabase/migrations/20260605163000_add_configurable_business_hours.sql`).
- Backend/types: atualiza tipagens geradas do Supabase para incluir `opening_time`/`closing_time` em `settings`. (`src/integrations/supabase/types.ts`).
- Helpers: adiciona `src/lib/businessHours.ts` com validação/normalização `HH:mm`, geração de slots e construção de limites de calendário reutilizáveis. 
- Frontend: integração das novas horas em várias telas: `GeneralSettingsForm` (inputs `type="time"`, validação `opening < closing`, salva `opening_time`/`closing_time` e invalida queries), agenda (`StableAgendaContent`, `ResilientAgendaContent`, `AgendaContent`, `AgendaCalendar`) para buscar `business-hours` por estabelecimento e passar `openTime`/`closeTime` ao calendário, e `PublicBooking` para gerar slots somente dentro do intervalo configurado.

### Testing
- `git diff --check` — OK (sem conflitos apontados).
- `npm run lint` — bloqueado por ambiente: `ESLint` falhou por falta de dependências locais (`@eslint/js` não encontrado).
- `npm run build` / `tsc -p tsconfig.app.json --noEmit` — bloqueado por dependências ausentes / lockfile fora de sincronia, causando erros de módulos faltantes durante a checagem TypeScript/build.
- `npm ci` / `npm install` — tentativas de instalar dependências falharam por lockfile desatualizado e/ou políticas do registro (403 em pacote), logo testes de build/lint/CI não puderam ser concluídos no ambiente atual.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22fc94620c83279075ce2b705e61db)