### PR TITLE
Support business-hours settings, normalize settings REST writes, and use them in public booking

### DIFF
--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -8,10 +8,67 @@ const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY;
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";
 
+type JsonRecord = Record<string, unknown>;
+
+const SETTINGS_REST_PATH = "/rest/v1/settings";
+
+function normalizeSettingsAliases(row: JsonRecord) {
+  const next = { ...row };
+
+  if ("opening_time" in next && !("business_open_time" in next)) {
+    next.business_open_time = next.opening_time;
+  }
+
+  if ("closing_time" in next && !("business_close_time" in next)) {
+    next.business_close_time = next.closing_time;
+  }
+
+  delete next.opening_time;
+  delete next.closing_time;
+
+  return next;
+}
+
+function normalizeSettingsRequestBody(body: BodyInit | null | undefined) {
+  if (typeof body !== "string" || !body.includes("closing_time") && !body.includes("opening_time")) {
+    return body;
+  }
+
+  const parsed = JSON.parse(body) as JsonRecord | JsonRecord[];
+  const normalized = Array.isArray(parsed)
+    ? parsed.map((row) => normalizeSettingsAliases(row))
+    : normalizeSettingsAliases(parsed);
+
+  return JSON.stringify(normalized);
+}
+
+function isSettingsWrite(input: RequestInfo | URL, init?: RequestInit) {
+  const url = input instanceof Request ? input.url : String(input);
+  const method = (init?.method ?? (input instanceof Request ? input.method : "GET")).toUpperCase();
+
+  return url.includes(SETTINGS_REST_PATH) && ["POST", "PATCH", "PUT"].includes(method);
+}
+
+const supabaseFetch: typeof fetch = (input, init) => {
+  if (!isSettingsWrite(input, init)) {
+    return fetch(input, init);
+  }
+
+  const nextInit = {
+    ...init,
+    body: normalizeSettingsRequestBody(init?.body),
+  };
+
+  return fetch(input, nextInit);
+};
+
 export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY, {
   auth: {
     storage: localStorage,
     persistSession: true,
     autoRefreshToken: true,
+  },
+  global: {
+    fetch: supabaseFetch,
   }
 });

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -927,28 +927,34 @@ export type Database = {
         Row: {
           business_close_time: string
           business_open_time: string
+          closing_time: string
           created_at: string
           establishment_id: string
           id: string
           inactive_days_threshold: number | null
+          opening_time: string
           updated_at: string
         }
         Insert: {
           business_close_time?: string
           business_open_time?: string
+          closing_time?: string
           created_at?: string
           establishment_id: string
           id?: string
           inactive_days_threshold?: number | null
+          opening_time?: string
           updated_at?: string
         }
         Update: {
           business_close_time?: string
           business_open_time?: string
+          closing_time?: string
           created_at?: string
           establishment_id?: string
           id?: string
           inactive_days_threshold?: number | null
+          opening_time?: string
           updated_at?: string
         }
         Relationships: [

--- a/src/pages/Agenda.tsx
+++ b/src/pages/Agenda.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useAuth } from "@/hooks/useAuth";
 import { Navigate } from "react-router-dom";
-import ResilientAgendaContent from "@/components/agenda/ResilientAgendaContent";
+import StableAgendaContent from "@/components/agenda/StableAgendaContent";
 
 export default function Agenda() {
   const { user } = useAuth();
@@ -25,7 +25,7 @@ export default function Agenda() {
         </div>
       </header>
       <main className="container mx-auto px-4 py-10 space-y-6">
-        <ResilientAgendaContent />
+        <StableAgendaContent />
       </main>
     </div>
   );

--- a/src/pages/PublicBooking.tsx
+++ b/src/pages/PublicBooking.tsx
@@ -4,14 +4,51 @@ import { supabase } from "@/integrations/supabase/client";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Calendar } from "@/components/ui/calendar";
-import { Calendar as CalendarIcon, ChevronDown } from "lucide-react";
+import { Calendar as CalendarIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { format, addMinutes, setHours, setMinutes, isSameDay } from "date-fns";
+import { format, isSameDay } from "date-fns";
 import { useToast } from "@/hooks/use-toast";
+
+
+const DEFAULT_OPENING_TIME = "08:00";
+const DEFAULT_CLOSING_TIME = "19:00";
+const TIME_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+function normalizeTimeValue(value: string | null | undefined, fallback: string): string {
+  const candidate = String(value ?? "").slice(0, 5);
+  return TIME_PATTERN.test(candidate) ? candidate : fallback;
+}
+
+function isBusinessHoursRangeValid(openingTime: string, closingTime: string): boolean {
+  const [openHours, openMinutes] = openingTime.split(":").map(Number);
+  const [closeHours, closeMinutes] = closingTime.split(":").map(Number);
+  return TIME_PATTERN.test(openingTime) && TIME_PATTERN.test(closingTime) && openHours * 60 + openMinutes < closeHours * 60 + closeMinutes;
+}
+
+function buildDateAtTime(baseDate: Date, value: string): Date {
+  const [hours, minutes] = value.split(":").map(Number);
+  const date = new Date(baseDate);
+  date.setHours(hours, minutes, 0, 0);
+  return date;
+}
+
+function generateBusinessSlots(date: Date, openingTime: string, closingTime: string, durationMinutes = 30, stepMinutes = 30): Date[] {
+  if (!isBusinessHoursRangeValid(openingTime, closingTime)) return [];
+
+  const end = buildDateAtTime(date, closingTime);
+  const slots: Date[] = [];
+  let current = buildDateAtTime(date, openingTime);
+
+  while (current.getTime() + durationMinutes * 60_000 <= end.getTime()) {
+    slots.push(new Date(current));
+    current = new Date(current.getTime() + stepMinutes * 60_000);
+  }
+
+  return slots;
+}
 
 interface Service { id: string; name: string; price: number; duration: number }
 interface Professional { id: string; name: string }
@@ -21,6 +58,7 @@ export default function PublicBooking() {
   const [resolvedId, setResolvedId] = useState<string | null>(null);
   const [salonName, setSalonName] = useState<string>("");
   const [acceptingBookings, setAcceptingBookings] = useState<boolean>(true);
+  const [businessHours, setBusinessHours] = useState({ openingTime: DEFAULT_OPENING_TIME, closingTime: DEFAULT_CLOSING_TIME });
   const [lookupState, setLookupState] = useState<"loading" | "ok" | "not_found">("loading");
   const [services, setServices] = useState<Service[]>([]);
   const [professionals, setProfessionals] = useState<Professional[]>([]);
@@ -60,6 +98,10 @@ export default function PublicBooking() {
         setResolvedId(salon.id);
         setSalonName(salon.business_name || "");
         setAcceptingBookings(salon.accepting_bookings !== false);
+        setBusinessHours({
+          openingTime: normalizeTimeValue(salon.opening_time, DEFAULT_OPENING_TIME),
+          closingTime: normalizeTimeValue(salon.closing_time, DEFAULT_CLOSING_TIME),
+        });
         setLookupState("ok");
         document.title = `${salon.business_name || "Agendar atendimento"} | Beauty Core`;
       } else if (establishmentId) {
@@ -72,6 +114,10 @@ export default function PublicBooking() {
         setResolvedId(salon.id);
         setSalonName(salon.business_name || "");
         setAcceptingBookings(salon.accepting_bookings !== false);
+        setBusinessHours({
+          openingTime: normalizeTimeValue(salon.opening_time, DEFAULT_OPENING_TIME),
+          closingTime: normalizeTimeValue(salon.closing_time, DEFAULT_CLOSING_TIME),
+        });
         setLookupState("ok");
       } else {
         setLookupState("not_found");
@@ -126,16 +172,8 @@ export default function PublicBooking() {
 
   const slots = useMemo(() => {
     if (!date) return [] as Date[];
-    const start = setMinutes(setHours(new Date(date), 9), 0); // 09:00
-    const end = setMinutes(setHours(new Date(date), 18), 0); // 18:00
-    const out: Date[] = [];
-    let cur = start;
-    while (cur <= end) {
-      out.push(new Date(cur));
-      cur = addMinutes(cur, 30);
-    }
-    return out;
-  }, [date]);
+    return generateBusinessSlots(date, businessHours.openingTime, businessHours.closingTime, Math.max(totalDuration, 30));
+  }, [businessHours.closingTime, businessHours.openingTime, date, totalDuration]);
 
   const isBooked = (d: Date) => {
     // compare by hour/minute on same day
@@ -150,7 +188,8 @@ export default function PublicBooking() {
   const handleSubmit = async () => {
     if (!canSubmit || !date) return;
     const [hh, mm] = slot.split(":").map(Number);
-    const startTime = setMinutes(setHours(new Date(date), hh), mm);
+    const startTime = new Date(date);
+    startTime.setHours(hh, mm, 0, 0);
     const { data, error } = await supabase.rpc("create_public_booking", {
       establishment: resolvedId!,
       client_name: clientName,

--- a/supabase/migrations/20260606123000_business_hours_public_settings.sql
+++ b/supabase/migrations/20260606123000_business_hours_public_settings.sql
@@ -1,0 +1,164 @@
+-- Consolidated business-hours migration to avoid filename conflicts with earlier PR attempts.
+-- Uses existing business_open_time/business_close_time as canonical columns and keeps
+-- opening_time/closing_time as compatibility aliases for clients that already shipped.
+
+ALTER TABLE public.settings
+  ADD COLUMN IF NOT EXISTS business_open_time time without time zone NOT NULL DEFAULT '08:00',
+  ADD COLUMN IF NOT EXISTS business_close_time time without time zone NOT NULL DEFAULT '19:00',
+  ADD COLUMN IF NOT EXISTS opening_time time without time zone,
+  ADD COLUMN IF NOT EXISTS closing_time time without time zone;
+
+UPDATE public.settings
+SET
+  business_open_time = COALESCE(business_open_time, opening_time, '08:00'::time),
+  business_close_time = COALESCE(business_close_time, closing_time, '19:00'::time),
+  opening_time = COALESCE(opening_time, business_open_time, '08:00'::time),
+  closing_time = COALESCE(closing_time, business_close_time, '19:00'::time)
+WHERE
+  business_open_time IS NULL
+  OR business_close_time IS NULL
+  OR opening_time IS NULL
+  OR closing_time IS NULL;
+
+ALTER TABLE public.settings
+  ALTER COLUMN opening_time SET NOT NULL,
+  ALTER COLUMN opening_time SET DEFAULT '08:00'::time,
+  ALTER COLUMN closing_time SET NOT NULL,
+  ALTER COLUMN closing_time SET DEFAULT '19:00'::time;
+
+ALTER TABLE public.settings
+  DROP CONSTRAINT IF EXISTS settings_business_hours_order_check,
+  DROP CONSTRAINT IF EXISTS settings_opening_closing_time_order_check;
+
+ALTER TABLE public.settings
+  ADD CONSTRAINT settings_business_hours_order_check CHECK (business_open_time < business_close_time),
+  ADD CONSTRAINT settings_opening_closing_time_order_check CHECK (opening_time < closing_time);
+
+CREATE OR REPLACE FUNCTION public.sync_settings_business_hours_aliases()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'public'
+AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    NEW.business_open_time := COALESCE(NEW.business_open_time, NEW.opening_time, '08:00'::time);
+    NEW.business_close_time := COALESCE(NEW.business_close_time, NEW.closing_time, '19:00'::time);
+    NEW.opening_time := COALESCE(NEW.opening_time, NEW.business_open_time, '08:00'::time);
+    NEW.closing_time := COALESCE(NEW.closing_time, NEW.business_close_time, '19:00'::time);
+  ELSE
+    IF NEW.opening_time IS DISTINCT FROM OLD.opening_time OR NEW.closing_time IS DISTINCT FROM OLD.closing_time THEN
+      NEW.business_open_time := NEW.opening_time;
+      NEW.business_close_time := NEW.closing_time;
+    ELSIF NEW.business_open_time IS DISTINCT FROM OLD.business_open_time OR NEW.business_close_time IS DISTINCT FROM OLD.business_close_time THEN
+      NEW.opening_time := NEW.business_open_time;
+      NEW.closing_time := NEW.business_close_time;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_sync_settings_business_hours_aliases ON public.settings;
+CREATE TRIGGER trg_sync_settings_business_hours_aliases
+BEFORE INSERT OR UPDATE OF opening_time, closing_time, business_open_time, business_close_time ON public.settings
+FOR EACH ROW
+EXECUTE FUNCTION public.sync_settings_business_hours_aliases();
+
+CREATE OR REPLACE FUNCTION public.get_public_salon_by_slug(p_slug text)
+RETURNS json
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE result json;
+BEGIN
+  SELECT json_build_object(
+    'id', p.id,
+    'business_name', p.business_name,
+    'city', p.city,
+    'accepting_bookings', p.accepting_bookings,
+    'opening_time', to_char(COALESCE(s.business_open_time, '08:00'::time), 'HH24:MI'),
+    'closing_time', to_char(COALESCE(s.business_close_time, '19:00'::time), 'HH24:MI')
+  )
+  INTO result
+  FROM public.profiles p
+  LEFT JOIN public.settings s ON s.establishment_id = p.id
+  WHERE p.slug = p_slug
+  LIMIT 1;
+
+  RETURN result;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_public_salon_by_id(p_id uuid)
+RETURNS json
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE result json;
+BEGIN
+  SELECT json_build_object(
+    'id', p.id,
+    'business_name', p.business_name,
+    'city', p.city,
+    'accepting_bookings', p.accepting_bookings,
+    'opening_time', to_char(COALESCE(s.business_open_time, '08:00'::time), 'HH24:MI'),
+    'closing_time', to_char(COALESCE(s.business_close_time, '19:00'::time), 'HH24:MI')
+  )
+  INTO result
+  FROM public.profiles p
+  LEFT JOIN public.settings s ON s.establishment_id = p.id
+  WHERE p.id = p_id
+  LIMIT 1;
+
+  RETURN result;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_public_salon_by_slug(text) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_public_salon_by_id(uuid) TO anon, authenticated;
+
+CREATE OR REPLACE FUNCTION public.upsert_general_settings(
+  p_establishment_id uuid,
+  p_inactive_days_threshold integer,
+  p_business_open_time time without time zone,
+  p_business_close_time time without time zone
+)
+RETURNS void
+LANGUAGE plpgsql
+SET search_path TO 'public'
+AS $$
+BEGIN
+  IF p_business_open_time >= p_business_close_time THEN
+    RAISE EXCEPTION 'O horário de abertura deve ser menor que o horário de fechamento';
+  END IF;
+
+  INSERT INTO public.settings (
+    establishment_id,
+    inactive_days_threshold,
+    business_open_time,
+    business_close_time
+  )
+  VALUES (
+    p_establishment_id,
+    p_inactive_days_threshold,
+    p_business_open_time,
+    p_business_close_time
+  )
+  ON CONFLICT (establishment_id) DO UPDATE
+  SET
+    inactive_days_threshold = EXCLUDED.inactive_days_threshold,
+    business_open_time = EXCLUDED.business_open_time,
+    business_close_time = EXCLUDED.business_close_time,
+    updated_at = now();
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.upsert_general_settings(uuid, integer, time without time zone, time without time zone) TO authenticated;
+
+-- Force PostgREST to refresh columns and RPC signatures immediately.
+SELECT pg_notify('pgrst', 'reload schema');


### PR DESCRIPTION
### Motivation

- Introduce canonical `business_open_time`/`business_close_time` while keeping `opening_time`/`closing_time` as compatibility aliases so clients and DB stay backward-compatible.
- Ensure REST writes to `settings` normalize alias fields so incoming requests using old names update canonical columns correctly.
- Use the consolidated business hours in the public booking UI to generate valid appointment slots and prevent invalid times.

### Description

- Add a consolidated DB migration `20260606123000_business_hours_public_settings.sql` that adds `business_open_time`/`business_close_time` columns, retains `opening_time`/`closing_time` aliases, backfills values, enforces ordering constraints, and creates a trigger `trg_sync_settings_business_hours_aliases` to keep aliases synchronized; also adds/updates RPCs `get_public_salon_by_slug`, `get_public_salon_by_id`, and `upsert_general_settings` and notifies PostgREST to reload schema.
- Extend Supabase client in `src/integrations/supabase/client.ts` with a `global.fetch` wrapper that intercepts writes to `/rest/v1/settings` and normalizes request bodies by mapping `opening_time`/`closing_time` to `business_open_time`/`business_close_time` before sending.
- Update DB types in `src/integrations/supabase/types.ts` to include both `opening_time`/`closing_time` and `business_open_time`/`business_close_time` for `settings` rows and operations.
- Update front-end booking logic in `src/pages/PublicBooking.tsx` to normalize times, validate ranges, generate appointment slots based on business hours and selected service duration, and set start times consistently; remove unused imports and adjust slot generation accordingly.
- Swap `ResilientAgendaContent` for `StableAgendaContent` in `src/pages/Agenda.tsx` to reflect the component rename.

### Testing

- Ran TypeScript type-check and build using `pnpm build` (or `tsc --noEmit`) and it completed successfully.
- Ran the existing automated test suite via `pnpm test` and the tests passed.
- Verified linting with `pnpm lint` and formatting checks which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22fc94620c83279075ce2b705e61db)