### PR TITLE
Fix duplicate settings save by using upsert

### DIFF
--- a/src/components/settings/GeneralSettingsForm.tsx
+++ b/src/components/settings/GeneralSettingsForm.tsx
@@ -69,18 +69,13 @@ export function GeneralSettingsForm({ establishmentId }: GeneralSettingsFormProp
         opening_time: openTime,
         closing_time: closeTime,
       };
-      if (data?.settings?.id) {
-        const { error } = await (supabase as any)
-          .from("settings")
-          .update(payload)
-          .eq("establishment_id", establishmentId);
-        if (error) throw error;
-      } else {
-        const { error } = await (supabase as any)
-          .from("settings")
-          .insert({ establishment_id: establishmentId, ...payload });
-        if (error) throw error;
-      }
+      const { error } = await (supabase as any)
+        .from("settings")
+        .upsert(
+          { establishment_id: establishmentId, ...payload },
+          { onConflict: "establishment_id" }
+        );
+      if (error) throw error;
       toast.success("Preferências salvas!");
       await Promise.all([
         refetch(),


### PR DESCRIPTION
### Motivation
- Prevent attempts to insert a second `settings` row for the same establishment (avoids `duplicate key value violates unique constraint "settings_establishment_id_key"`) when saving preferences.

### Description
- Replace conditional `insert`/`update` in `src/components/settings/GeneralSettingsForm.tsx` with a single `upsert` on `establishment_id` so saving preferences updates or inserts atomically using `onConflict: "establishment_id"`.
- Preserve the existing `refetch`/`invalidateQueries` calls so `agenda` and `business-hours` continue to refresh after saving.

### Testing
- Ran `npm run lint` which failed due to missing dependencies (`@eslint/js` not found) so lint could not be completed in this environment.
- Ran `npm ci` which failed because `package-lock.json` is out of sync with `package.json`, so a clean install could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25c8b7d94883279cb5c6ac98bb6722)