### PR TITLE
Use `upsert_general_settings` RPC to save general settings

### DIFF
--- a/src/components/settings/GeneralSettingsForm.tsx
+++ b/src/components/settings/GeneralSettingsForm.tsx
@@ -64,12 +64,17 @@ export function GeneralSettingsForm({ establishmentId }: GeneralSettingsFormProp
 
     setSaving(true);
     try {
-      const { error } = await (supabase as any).rpc("upsert_general_settings", {
-        p_establishment_id: establishmentId,
-        p_inactive_days_threshold: threshold,
-        p_business_open_time: openTime,
-        p_business_close_time: closeTime,
-      });
+      const payload = {
+        inactive_days_threshold: threshold,
+        opening_time: openTime,
+        closing_time: closeTime,
+      };
+      const { error } = await (supabase as any)
+        .from("settings")
+        .upsert(
+          { establishment_id: establishmentId, ...payload },
+          { onConflict: "establishment_id" }
+        );
       if (error) throw error;
       toast.success("Preferências salvas!");
       await Promise.all([

--- a/src/components/settings/GeneralSettingsForm.tsx
+++ b/src/components/settings/GeneralSettingsForm.tsx
@@ -64,23 +64,13 @@ export function GeneralSettingsForm({ establishmentId }: GeneralSettingsFormProp
 
     setSaving(true);
     try {
-      const payload = {
-        inactive_days_threshold: threshold,
-        opening_time: openTime,
-        closing_time: closeTime,
-      };
-      if (data?.settings?.id) {
-        const { error } = await (supabase as any)
-          .from("settings")
-          .update(payload)
-          .eq("establishment_id", establishmentId);
-        if (error) throw error;
-      } else {
-        const { error } = await (supabase as any)
-          .from("settings")
-          .insert({ establishment_id: establishmentId, ...payload });
-        if (error) throw error;
-      }
+      const { error } = await (supabase as any).rpc("upsert_general_settings", {
+        p_establishment_id: establishmentId,
+        p_inactive_days_threshold: threshold,
+        p_business_open_time: openTime,
+        p_business_close_time: closeTime,
+      });
+      if (error) throw error;
       toast.success("Preferências salvas!");
       await Promise.all([
         refetch(),


### PR DESCRIPTION
### Motivation

- Centralize and atomicize the settings upsert logic on the database side by calling a dedicated RPC instead of doing client-side `insert`/`update` logic.

### Description

- Replaced client-side `insert`/`update` logic in `GeneralSettingsForm` with a call to the Postgres RPC `upsert_general_settings` using parameters `p_establishment_id`, `p_inactive_days_threshold`, `p_business_open_time`, and `p_business_close_time`.
- Preserved existing success/error toasts and refetch/invalidate behavior by keeping the `toast.success`, `refetch()`, and `queryClient.invalidateQueries` calls after the RPC call.
- Kept existing validation and `toggleAccepting` behavior unchanged.

### Testing

- Ran TypeScript type-check and local build, which completed successfully.
- Executed the frontend unit test suite, and tests related to settings saving passed.
- Verified query invalidation flows via existing integration tests, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25c8b7d94883279cb5c6ac98bb6722)