### PR TITLE
Add appointment_blocks migration, handle schema/cache errors, and use upsert for settings

### DIFF
--- a/src/components/agenda/AppointmentBlockDialog.tsx
+++ b/src/components/agenda/AppointmentBlockDialog.tsx
@@ -30,6 +30,28 @@ function toLocalInput(date: Date) {
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
 }
 
+function isAppointmentBlocksSchemaError(error: any) {
+  if (!error) return false;
+
+  const code = String(error.code ?? "");
+  const message = `${error.message ?? ""} ${error.details ?? ""} ${error.hint ?? ""}`.toLowerCase();
+
+  return (
+    ["42P01", "PGRST205"].includes(code) ||
+    message.includes("appointment_blocks") ||
+    message.includes("schema cache") ||
+    message.includes("could not find")
+  );
+}
+
+function getBlockPersistenceErrorMessage(error: any) {
+  if (isAppointmentBlocksSchemaError(error)) {
+    return "O recurso de bloqueio ainda não está disponível no banco. Aplique as migrations e aguarde o schema cache atualizar.";
+  }
+
+  return error?.message ?? "Não foi possível salvar o bloqueio.";
+}
+
 export function AppointmentBlockDialog({
   open,
   onOpenChange,
@@ -88,7 +110,7 @@ export function AppointmentBlockDialog({
 
     setSaving(false);
     if (error) {
-      toast({ title: "Erro ao salvar bloqueio", description: error.message, variant: "destructive" });
+      toast({ title: "Erro ao salvar bloqueio", description: getBlockPersistenceErrorMessage(error), variant: "destructive" });
       return;
     }
 
@@ -103,7 +125,7 @@ export function AppointmentBlockDialog({
     const { error } = await (supabase as any).from("appointment_blocks").delete().eq("id", block.id);
     setSaving(false);
     if (error) {
-      toast({ title: "Erro ao excluir bloqueio", description: error.message, variant: "destructive" });
+      toast({ title: "Erro ao excluir bloqueio", description: getBlockPersistenceErrorMessage(error), variant: "destructive" });
       return;
     }
     toast({ title: "Bloqueio removido" });

--- a/src/components/settings/GeneralSettingsForm.tsx
+++ b/src/components/settings/GeneralSettingsForm.tsx
@@ -69,18 +69,13 @@ export function GeneralSettingsForm({ establishmentId }: GeneralSettingsFormProp
         opening_time: openTime,
         closing_time: closeTime,
       };
-      if (data?.settings?.id) {
-        const { error } = await (supabase as any)
-          .from("settings")
-          .update(payload)
-          .eq("establishment_id", establishmentId);
-        if (error) throw error;
-      } else {
-        const { error } = await (supabase as any)
-          .from("settings")
-          .insert({ establishment_id: establishmentId, ...payload });
-        if (error) throw error;
-      }
+      const { error } = await (supabase as any)
+        .from("settings")
+        .upsert(
+          { establishment_id: establishmentId, ...payload },
+          { onConflict: "establishment_id" }
+        );
+      if (error) throw error;
       toast.success("Preferências salvas!");
       await Promise.all([
         refetch(),

--- a/supabase/migrations/20260608120000_ensure_appointment_blocks_schema_cache.sql
+++ b/supabase/migrations/20260608120000_ensure_appointment_blocks_schema_cache.sql
@@ -1,0 +1,75 @@
+-- Ensure appointment time blocks exist in deployed databases and refresh PostgREST's schema cache.
+-- Some environments may have shipped the agenda UI before this support table was available.
+
+CREATE TABLE IF NOT EXISTS public.appointment_blocks (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  establishment_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  professional_id uuid NOT NULL REFERENCES public.professionals(id) ON DELETE CASCADE,
+  start_time timestamptz NOT NULL,
+  end_time timestamptz NOT NULL,
+  reason text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT appointment_blocks_valid_range CHECK (end_time > start_time)
+);
+
+ALTER TABLE public.appointment_blocks
+  ADD COLUMN IF NOT EXISTS establishment_id uuid REFERENCES public.profiles(id) ON DELETE CASCADE,
+  ADD COLUMN IF NOT EXISTS professional_id uuid REFERENCES public.professionals(id) ON DELETE CASCADE,
+  ADD COLUMN IF NOT EXISTS start_time timestamptz,
+  ADD COLUMN IF NOT EXISTS end_time timestamptz,
+  ADD COLUMN IF NOT EXISTS reason text,
+  ADD COLUMN IF NOT EXISTS created_at timestamptz NOT NULL DEFAULT now(),
+  ADD COLUMN IF NOT EXISTS updated_at timestamptz NOT NULL DEFAULT now();
+
+ALTER TABLE public.appointment_blocks
+  ALTER COLUMN establishment_id SET NOT NULL,
+  ALTER COLUMN professional_id SET NOT NULL,
+  ALTER COLUMN start_time SET NOT NULL,
+  ALTER COLUMN end_time SET NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'appointment_blocks_valid_range'
+      AND conrelid = 'public.appointment_blocks'::regclass
+  ) THEN
+    ALTER TABLE public.appointment_blocks
+      ADD CONSTRAINT appointment_blocks_valid_range CHECK (end_time > start_time);
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_appointment_blocks_professional_range
+  ON public.appointment_blocks (establishment_id, professional_id, start_time, end_time);
+
+ALTER TABLE public.appointment_blocks ENABLE ROW LEVEL SECURITY;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.appointment_blocks TO authenticated;
+GRANT ALL ON public.appointment_blocks TO service_role;
+
+DROP POLICY IF EXISTS appointment_blocks_establishment_access ON public.appointment_blocks;
+CREATE POLICY appointment_blocks_establishment_access
+  ON public.appointment_blocks
+  FOR ALL
+  TO authenticated
+  USING (
+    establishment_id = public.current_establishment_id()
+    OR public.is_establishment_member(establishment_id, auth.uid())
+    OR establishment_id IN (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+  )
+  WITH CHECK (
+    establishment_id = public.current_establishment_id()
+    OR public.is_establishment_member(establishment_id, auth.uid())
+    OR establishment_id IN (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+  );
+
+DROP TRIGGER IF EXISTS update_appointment_blocks_updated_at ON public.appointment_blocks;
+CREATE TRIGGER update_appointment_blocks_updated_at
+  BEFORE UPDATE ON public.appointment_blocks
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+-- Force PostgREST to see the table immediately after this migration is applied.
+SELECT pg_notify('pgrst', 'reload schema');


### PR DESCRIPTION
### Motivation

- Ensure the `appointment_blocks` table exists in deployed databases and force PostgREST to reload the schema so the agenda UI won't fail in environments that shipped before the table existed. 
- Surface a clearer, actionable error message to users when persistence fails due to missing schema or schema cache issues. 
- Simplify settings persistence by using a single `upsert` rather than separate insert/update branches.

### Description

- Add migration `supabase/migrations/20260608120000_ensure_appointment_blocks_schema_cache.sql` that creates `public.appointment_blocks` (with columns, constraint, index, RLS, policies, trigger) and calls `SELECT pg_notify('pgrst', 'reload schema')` to refresh PostgREST schema cache immediately. 
- Add `isAppointmentBlocksSchemaError` and `getBlockPersistenceErrorMessage` helpers in `src/components/agenda/AppointmentBlockDialog.tsx` and use them to show a localized, actionable toast when DB/schema/cache issues are detected. 
- Replace the conditional insert/update logic in `src/components/settings/GeneralSettingsForm.tsx` with a single `upsert(..., { onConflict: "establishment_id" })` call to simplify saving settings. 
- Update toast messages in appointment block save/remove flows to use the new error-message helper.

### Testing

- Ran the existing frontend test suite via `yarn test`; all tests passed. 
- No new automated DB migration tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25c8b7d94883279cb5c6ac98bb6722)