### PR TITLE
Implement store payment access blocking

### DIFF
--- a/src/components/StoreBlockedGate.tsx
+++ b/src/components/StoreBlockedGate.tsx
@@ -1,5 +1,5 @@
 import { useLocation, useNavigate } from "react-router-dom";
-import { AlertTriangle } from "lucide-react";
+import { CreditCard, MessageCircle } from "lucide-react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -9,25 +9,21 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { useSubscription, type SubscriptionState } from "@/hooks/useSubscription";
-import { useAuth } from "@/hooks/useAuth";
-
-const BLOCKED_STATES = new Set<SubscriptionState>([
-  "overdue",
-  "overdue_partial",
-  "overdue_blocked",
-  "blocked",
-  "no_subscription",
-]);
+import { Button } from "@/components/ui/button";
+import { isFullyBlocked, useSubscription, type SubscriptionInfo } from "@/hooks/useSubscription";
 
 // Rotas permitidas mesmo com a loja bloqueada
 const ALLOWED_PATHS = ["/escolher-plano", "/checkout", "/planos"];
+const SUPPORT_WHATSAPP_URL = "https://wa.me/5511917506368";
+
+export function isStoreBlocked(subscription: SubscriptionInfo | null | undefined) {
+  if (!subscription) return false;
+  return isFullyBlocked(subscription.state);
+}
 
 export function useStoreBlocked() {
   const { data } = useSubscription();
-  if (!data) return false;
-  const isActivePaid = data.status === "active" && !!data.plan_id;
-  return !isActivePaid && BLOCKED_STATES.has(data.state);
+  return isStoreBlocked(data);
 }
 
 export default function StoreBlockedGate() {
@@ -39,22 +35,36 @@ export default function StoreBlockedGate() {
   if (ALLOWED_PATHS.some((p) => location.pathname.startsWith(p))) return null;
 
   return (
-    <AlertDialog open>
-      <AlertDialogContent className="border-destructive/40">
-        <AlertDialogHeader>
-          <div className="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-destructive/15 text-destructive">
-            <AlertTriangle className="h-6 w-6" />
+    <AlertDialog open onOpenChange={() => undefined}>
+      <AlertDialogContent className="max-w-md border-0 bg-card p-8 text-center shadow-2xl sm:rounded-3xl [&>button]:hidden">
+        <AlertDialogHeader className="items-center space-y-4 text-center">
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-destructive/10 text-destructive">
+            <CreditCard className="h-8 w-8" />
           </div>
-          <AlertDialogTitle className="text-center">Loja bloqueada</AlertDialogTitle>
-          <AlertDialogDescription className="text-center">
-            Sua loja foi bloqueada porque não encontramos um pagamento ativo.
-            Assine ou reative seu plano para continuar usando o sistema.
+          <AlertDialogTitle className="text-center text-2xl font-bold leading-tight text-foreground">
+            Ops! Algo deu errado com o seu pagamento.
+          </AlertDialogTitle>
+          <AlertDialogDescription className="text-center text-base leading-relaxed text-muted-foreground">
+            O seu pagamento não foi identificado, e isso levou à suspensão temporária do seu acesso ao sistema.
           </AlertDialogDescription>
         </AlertDialogHeader>
-        <AlertDialogFooter className="sm:justify-center">
-          <AlertDialogAction onClick={() => navigate("/escolher-plano")}>
-            Ver planos
+
+        <AlertDialogFooter className="mt-2 flex-col gap-3 sm:flex-col sm:space-x-0">
+          <AlertDialogAction
+            className="h-12 w-full rounded-full text-base font-semibold"
+            onClick={() => navigate("/planos")}
+          >
+            Pagar boleto
           </AlertDialogAction>
+          <Button
+            type="button"
+            variant="link"
+            className="gap-2 text-muted-foreground hover:text-foreground"
+            onClick={() => window.open(SUPPORT_WHATSAPP_URL, "_blank", "noopener,noreferrer")}
+          >
+            <MessageCircle className="h-4 w-4" />
+            Conversar com o suporte
+          </Button>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/src/components/TrialExpiredBanner.tsx
+++ b/src/components/TrialExpiredBanner.tsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router-dom";
 import { AlertTriangle } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { useSubscription } from "@/hooks/useSubscription";
+import { isFullyBlocked, useSubscription } from "@/hooks/useSubscription";
 import { useAuth } from "@/hooks/useAuth";
 
 const EXPIRED_STATES = new Set([
@@ -19,9 +19,8 @@ export default function TrialExpiredBanner() {
   const isOwner = establishmentRole === "owner" || establishmentRole === null;
   if (!isOwner || !data) return null;
 
-  // Considera trial expirado / inadimplente quando não há assinatura ativa
-  const isActivePaid = data.status === "active" && !!data.plan_id;
-  const shouldShow = !isActivePaid && EXPIRED_STATES.has(data.state);
+  // Considera trial expirado / inadimplente pelo estado calculado no backend.
+  const shouldShow = isFullyBlocked(data.state) && EXPIRED_STATES.has(data.state);
   if (!shouldShow) return null;
 
   return (
@@ -34,7 +33,7 @@ export default function TrialExpiredBanner() {
           </span>
         </div>
         <Button asChild size="sm" variant="secondary" className="shrink-0">
-          <Link to="/escolher-plano">Escolher plano</Link>
+          <Link to="/planos">Pagar boleto</Link>
         </Button>
       </div>
     </div>

--- a/src/components/admin/AdminCompanies.tsx
+++ b/src/components/admin/AdminCompanies.tsx
@@ -146,7 +146,16 @@ export default function AdminCompanies() {
   async function changeStatus(row: Row, status: string, action: string) {
     if (!row.subscription || row.subscription.inferred) return;
     const updates: any = { status };
-    if (status === "canceled" || status === "blocked") updates.canceled_at = new Date().toISOString();
+    if (status === "blocked") {
+      updates.manual_blocked_at = new Date().toISOString();
+      updates.manual_blocked_reason = "Bloqueio manual pelo Super Admin";
+      updates.canceled_at = new Date().toISOString();
+    }
+    if (status === "canceled") updates.canceled_at = new Date().toISOString();
+    if (status !== "blocked") {
+      updates.manual_blocked_at = null;
+      updates.manual_blocked_reason = null;
+    }
     const { error } = await (supabase as any)
       .from("subscriptions")
       .update(updates)

--- a/src/hooks/useSubscription.tsx
+++ b/src/hooks/useSubscription.tsx
@@ -29,6 +29,10 @@ export interface SubscriptionInfo {
   trial_ends_at: string | null;
   next_billing_at: string | null;
   monthly_amount: number;
+  created_at?: string | null;
+  last_payment_at?: string | null;
+  asaas_subscription_id?: string | null;
+  manual_blocked_at?: string | null;
   payment_link?: string | null;
 }
 
@@ -53,7 +57,7 @@ export function daysBetween(target: string | null | undefined): number | null {
 
 export function canCreateAppointments(state?: SubscriptionState) {
   if (!state) return true;
-  return !["overdue_partial", "overdue_blocked", "blocked", "no_subscription"].includes(state);
+  return ["trial_active", "trial_expiring", "active_paid", "payment_pending"].includes(state);
 }
 
 export function canCreateClients(state?: SubscriptionState) {
@@ -61,5 +65,5 @@ export function canCreateClients(state?: SubscriptionState) {
 }
 
 export function isFullyBlocked(state?: SubscriptionState) {
-  return state === "overdue_blocked" || state === "blocked";
+  return ["overdue", "overdue_partial", "overdue_blocked", "blocked", "no_subscription"].includes(state ?? "no_subscription");
 }

--- a/supabase/functions/asaas-webhook/index.ts
+++ b/supabase/functions/asaas-webhook/index.ts
@@ -65,12 +65,12 @@ Deno.serve(async (req) => {
 
       // Update subscription state based on event
       const updates: Record<string, unknown> = {};
-      const updates: Record<string, unknown> = {};
       switch (event) {
         case 'PAYMENT_CONFIRMED':
         case 'PAYMENT_RECEIVED': {
           updates.status = 'active';
           updates.last_payment_at = new Date().toISOString();
+          updates.canceled_at = null;
           const base = payment.dueDate ? new Date(payment.dueDate) : new Date();
           base.setDate(base.getDate() + 30);
           updates.next_billing_at = base.toISOString();

--- a/supabase/migrations/20260609090000_enforce_store_payment_block.sql
+++ b/supabase/migrations/20260609090000_enforce_store_payment_block.sql
@@ -1,0 +1,211 @@
+-- Enforce automatic/manual store blocking from trial age and Asaas paid subscription status.
+
+ALTER TABLE public.subscriptions
+  ADD COLUMN IF NOT EXISTS manual_blocked_at timestamptz,
+  ADD COLUMN IF NOT EXISTS manual_blocked_reason text;
+
+CREATE INDEX IF NOT EXISTS idx_subscriptions_manual_blocked
+  ON public.subscriptions(manual_blocked_at)
+  WHERE manual_blocked_at IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION public.create_trial_subscription()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  selected_plan public.subscription_plans%ROWTYPE;
+BEGIN
+  SELECT sp.* INTO selected_plan
+  FROM public.subscription_plans sp
+  WHERE sp.slug = NEW.selected_plan_slug
+    AND sp.active = true
+  LIMIT 1;
+
+  INSERT INTO public.subscriptions (establishment_id, plan_id, status, trial_ends_at, monthly_amount)
+  VALUES (
+    NEW.id,
+    selected_plan.id,
+    'trial',
+    NEW.created_at + interval '10 days',
+    coalesce(selected_plan.monthly_price, 0)
+  )
+  ON CONFLICT (establishment_id) DO UPDATE SET
+    plan_id = coalesce(public.subscriptions.plan_id, EXCLUDED.plan_id),
+    monthly_amount = CASE
+      WHEN public.subscriptions.monthly_amount = 0 THEN EXCLUDED.monthly_amount
+      ELSE public.subscriptions.monthly_amount
+    END,
+    trial_ends_at = coalesce(public.subscriptions.trial_ends_at, EXCLUDED.trial_ends_at),
+    updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+UPDATE public.subscriptions s
+SET trial_ends_at = p.created_at + interval '10 days',
+    updated_at = now()
+FROM public.profiles p
+WHERE s.establishment_id = p.id
+  AND s.status = 'trial'
+  AND (
+    s.trial_ends_at IS NULL
+    OR s.trial_ends_at <> p.created_at + interval '10 days'
+  );
+
+CREATE OR REPLACE FUNCTION public.get_subscription_state(_establishment_id uuid)
+RETURNS text
+LANGUAGE plpgsql
+STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  s RECORD;
+  profile_created_at timestamptz;
+  trial_ends_at timestamptz;
+  days_left numeric;
+BEGIN
+  SELECT created_at INTO profile_created_at
+  FROM public.profiles
+  WHERE id = _establishment_id
+  LIMIT 1;
+
+  SELECT status, trial_ends_at, next_billing_at, asaas_subscription_id, last_payment_at, manual_blocked_at
+    INTO s
+  FROM public.subscriptions
+  WHERE establishment_id = _establishment_id
+  LIMIT 1;
+
+  IF NOT FOUND THEN
+    IF profile_created_at IS NOT NULL AND profile_created_at + interval '10 days' > now() THEN
+      RETURN 'trial_active';
+    END IF;
+    RETURN 'no_subscription';
+  END IF;
+
+  IF s.manual_blocked_at IS NOT NULL OR s.status = 'blocked' THEN
+    RETURN 'blocked';
+  END IF;
+
+  IF s.status = 'canceled' THEN
+    RETURN 'blocked';
+  END IF;
+
+  trial_ends_at := coalesce(profile_created_at + interval '10 days', s.trial_ends_at);
+
+  IF s.status = 'active'
+     AND s.asaas_subscription_id IS NOT NULL
+     AND s.last_payment_at IS NOT NULL THEN
+    IF s.next_billing_at IS NULL OR s.next_billing_at > now() THEN
+      IF s.next_billing_at IS NOT NULL THEN
+        days_left := EXTRACT(EPOCH FROM (s.next_billing_at - now())) / 86400;
+        IF days_left <= 5 THEN RETURN 'payment_pending'; END IF;
+      END IF;
+      RETURN 'active_paid';
+    END IF;
+  END IF;
+
+  IF trial_ends_at IS NOT NULL AND trial_ends_at > now() THEN
+    days_left := EXTRACT(EPOCH FROM (trial_ends_at - now())) / 86400;
+    IF days_left <= 3 THEN RETURN 'trial_expiring'; END IF;
+    RETURN 'trial_active';
+  END IF;
+
+  RETURN 'overdue_blocked';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.has_active_subscription(_establishment_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+  SELECT public.get_subscription_state(_establishment_id) IN ('trial_active','trial_expiring','active_paid','payment_pending');
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_my_subscription()
+RETURNS json
+LANGUAGE plpgsql
+STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  est_id uuid;
+  s RECORD;
+  p RECORD;
+  plan_json json;
+  state text;
+  sub_found boolean;
+  profile_created_at timestamptz;
+BEGIN
+  SELECT id, created_at INTO est_id, profile_created_at FROM public.profiles WHERE user_id = auth.uid() LIMIT 1;
+
+  IF est_id IS NULL THEN
+    SELECT eu.establishment_id, pr.created_at INTO est_id, profile_created_at
+    FROM public.establishment_users eu
+    JOIN public.profiles pr ON pr.id = eu.establishment_id
+    WHERE eu.user_id = auth.uid() AND eu.active = true
+    LIMIT 1;
+  END IF;
+
+  IF est_id IS NULL THEN RETURN NULL; END IF;
+
+  SELECT * INTO s FROM public.subscriptions WHERE establishment_id = est_id LIMIT 1;
+  sub_found := FOUND;
+  state := public.get_subscription_state(est_id);
+
+  IF NOT sub_found THEN
+    RETURN json_build_object(
+      'establishment_id', est_id,
+      'state', state,
+      'status', 'missing',
+      'plan_id', NULL,
+      'plan', NULL,
+      'created_at', profile_created_at,
+      'trial_ends_at', profile_created_at + interval '10 days',
+      'next_billing_at', NULL,
+      'last_payment_at', NULL,
+      'asaas_subscription_id', NULL,
+      'manual_blocked_at', NULL,
+      'monthly_amount', 0,
+      'payment_link', NULL
+    );
+  END IF;
+
+  IF s.plan_id IS NOT NULL THEN
+    SELECT id, slug, name, monthly_price, max_clients, max_users INTO p
+    FROM public.subscription_plans WHERE id = s.plan_id;
+    IF FOUND THEN
+      plan_json := json_build_object(
+        'id', p.id, 'slug', p.slug, 'name', p.name,
+        'monthly_price', p.monthly_price,
+        'max_clients', p.max_clients, 'max_users', p.max_users
+      );
+    END IF;
+  END IF;
+
+  RETURN json_build_object(
+    'establishment_id', est_id,
+    'state', state,
+    'status', s.status,
+    'plan_id', s.plan_id,
+    'plan', plan_json,
+    'created_at', profile_created_at,
+    'trial_ends_at', coalesce(profile_created_at + interval '10 days', s.trial_ends_at),
+    'next_billing_at', s.next_billing_at,
+    'last_payment_at', s.last_payment_at,
+    'asaas_subscription_id', s.asaas_subscription_id,
+    'manual_blocked_at', s.manual_blocked_at,
+    'monthly_amount', coalesce(s.monthly_amount, 0),
+    'payment_link', s.payment_link
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_subscription_state(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.has_active_subscription(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_my_subscription() TO authenticated;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
### Motivation

- Enforce automatic blocking of stores whose trial has expired (10 days after creation) and that do not have an active/paid AsaaS subscription. 
- Allow Super Admins to manually block a store and make manual blocks behave exactly like automatic payment blocks. 
- Always show a non-dismissible payment modal that prevents any use of the app while the store is blocked, while still allowing access to the plans/checkout pages and the support link.

### Description

- Add a DB migration `supabase/migrations/20260609090000_enforce_store_payment_block.sql` that stores `manual_blocked_at`/`manual_blocked_reason`, sets trial windows to `profile.created_at + interval '10 days'`, computes `get_subscription_state`, exposes `has_active_subscription` and enriches `get_my_subscription` to return payment and manual block fields. 
- Update the AsaaS webhook in `supabase/functions/asaas-webhook/index.ts` to set `last_payment_at`, clear `canceled_at` on confirmed payments and update `next_billing_at` so the system can automatically release blocks when AsaaS marks payments as active. 
- Frontend: replace the previous gate with a centered, non-dismissible modal in `src/components/StoreBlockedGate.tsx` that shows the requested title/description, a `Pagar boleto` action to `/planos` and a `Conversar com o suporte` link opening WhatsApp to `5511917506368`. 
- Frontend: adjust subscription hook and helpers in `src/hooks/useSubscription.tsx` to consume the computed state and expose `isFullyBlocked`/creation/payment fields, update `TrialExpiredBanner.tsx` to rely on the computed state, and wire Super Admin manual blocking in `src/components/admin/AdminCompanies.tsx` to set/clear `manual_blocked_at` and reason.

### Testing

- `git diff --check` ran and reported no diff/check errors. 
- `npm run lint` was attempted but failed in the environment due to missing local dev dependencies (`@eslint/js`), so lint could not complete here. 
- `npm run build` was attempted but failed in the environment due to missing local dev dependencies (`vite`), so a full build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a283d43c03c832799ef237e67dc162a)