### PR TITLE
Add Agendor signup lead integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,21 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Integração Agendor
+
+A função Supabase `agendor-create-signup-lead` cria automaticamente uma empresa e um negócio no Agendor sempre que um cadastro de salão é concluído no formulário de signup.
+
+Configure os secrets da função antes de publicar:
+
+```sh
+supabase secrets set AGENDOR_API_KEY="seu-token-do-agendor"
+```
+
+Secrets opcionais:
+
+- `AGENDOR_OWNER_USER`: ID ou email do responsável pelo lead no Agendor.
+- `AGENDOR_LEAD_ORIGIN`: ID ou nome da origem do lead no Agendor.
+- `AGENDOR_CATEGORY`: ID ou nome da categoria da empresa no Agendor.
+- `AGENDOR_DEAL_STAGE`: sequência da etapa inicial do negócio; por padrão usa `1`.
+- `AGENDOR_FUNNEL`: ID do funil, se a etapa pertencer a um funil específico.

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -117,7 +117,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
 
   const signUp = async (email: string, password: string, metadata?: any) => {
     const redirectUrl = `${window.location.origin}/`;
-    
+
     const { error } = await supabase.auth.signUp({
       email,
       password,
@@ -134,6 +134,17 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         variant: "destructive",
       });
     } else {
+      const { error: agendorError } = await supabase.functions.invoke('agendor-create-signup-lead', {
+        body: {
+          ...metadata,
+          email,
+        },
+      });
+
+      if (agendorError) {
+        console.error('Erro ao enviar cadastro para o Agendor:', agendorError);
+      }
+
       toast({
         title: "Cadastro realizado!",
         description: "Verifique seu email para confirmar a conta.",

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -2,3 +2,5 @@ project_id = "gikjhasawuhylrpchfqv"
 
 [functions.asaas-webhook]
 verify_jwt = false
+[functions.agendor-create-signup-lead]
+verify_jwt = false

--- a/supabase/functions/agendor-create-signup-lead/index.ts
+++ b/supabase/functions/agendor-create-signup-lead/index.ts
@@ -1,0 +1,223 @@
+/* global Deno */
+import { corsHeaders } from 'npm:@supabase/supabase-js@2/cors';
+
+const AGENDOR_BASE_URL = 'https://api.agendor.com.br/v3';
+
+type SignupLeadBody = {
+  business_name?: string;
+  document?: string;
+  owner_name?: string;
+  email?: string;
+  phone?: string;
+  cep?: string;
+  street?: string;
+  neighborhood?: string;
+  city?: string;
+  business_type?: string;
+  selected_plan?: string;
+};
+
+type AgendorResponse<T = Record<string, unknown>> = {
+  data?: T;
+  [key: string]: unknown;
+};
+
+function onlyDigits(value?: string) {
+  return (value ?? '').replace(/\D/g, '');
+}
+
+function compactObject<T extends Record<string, unknown>>(object: T) {
+  return Object.fromEntries(
+    Object.entries(object).filter(([, value]) => {
+      if (value === undefined || value === null) return false;
+      if (typeof value === 'string' && value.trim() === '') return false;
+      return true;
+    }),
+  ) as Partial<T>;
+}
+
+function envValueAsNumberOrString(name: string) {
+  const value = Deno.env.get(name)?.trim();
+  if (!value) return undefined;
+
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue) && /^\d+$/.test(value) ? numericValue : value;
+}
+
+function normalizeText(value?: string) {
+  return value?.trim() || undefined;
+}
+
+function normalizePhone(value?: string) {
+  const digits = onlyDigits(value);
+  return digits || normalizeText(value);
+}
+
+function getAgendorHeaders(apiKey: string) {
+  return {
+    authorization: `Token ${apiKey}`,
+    'content-type': 'application/json',
+    'User-Agent': 'SalaoPro/1.0',
+  };
+}
+
+async function parseAgendorResponse<T>(response: Response) {
+  const payload = await response.json().catch(() => ({})) as AgendorResponse<T>;
+
+  if (!response.ok) {
+    throw new Error(`Agendor ${response.status}: ${JSON.stringify(payload)}`);
+  }
+
+  return payload;
+}
+
+async function agendorRequest<T>(path: string, init: RequestInit, apiKey: string) {
+  const response = await fetch(`${AGENDOR_BASE_URL}${path}`, {
+    ...init,
+    headers: {
+      ...getAgendorHeaders(apiKey),
+      ...(init.headers ?? {}),
+    },
+  });
+
+  return parseAgendorResponse<T>(response);
+}
+
+function buildOrganizationPayload(body: SignupLeadBody) {
+  const documentDigits = onlyDigits(body.document);
+  const phone = normalizePhone(body.phone);
+  const ownerName = normalizeText(body.owner_name);
+  const businessType = normalizeText(body.business_type);
+  const selectedPlan = normalizeText(body.selected_plan);
+
+  return compactObject({
+    name: normalizeText(body.business_name) ?? 'Salão sem nome',
+    cnpj: documentDigits.length === 14 ? documentDigits : undefined,
+    description: [
+      ownerName ? `Responsável: ${ownerName}` : undefined,
+      businessType ? `Tipo de negócio: ${businessType}` : undefined,
+      selectedPlan ? `Plano escolhido: ${selectedPlan}` : undefined,
+      documentDigits && documentDigits.length !== 14 ? `Documento informado no cadastro: ${documentDigits}` : undefined,
+      'Origem: cadastro no SalaoPro',
+    ].filter(Boolean).join('\n'),
+    contact: compactObject({
+      email: normalizeText(body.email),
+      work: phone,
+      mobile: phone,
+      whatsapp: phone,
+    }),
+    address: compactObject({
+      country: 'Brasil',
+      postalCode: normalizeText(body.cep),
+      streetName: normalizeText(body.street),
+      district: normalizeText(body.neighborhood),
+      city: normalizeText(body.city),
+    }),
+    leadOrigin: envValueAsNumberOrString('AGENDOR_LEAD_ORIGIN'),
+    category: envValueAsNumberOrString('AGENDOR_CATEGORY'),
+    ownerUser: envValueAsNumberOrString('AGENDOR_OWNER_USER'),
+    allowToAllUsers: true,
+  });
+}
+
+function buildDealPayload(body: SignupLeadBody) {
+  const businessName = normalizeText(body.business_name) ?? 'Salão sem nome';
+  const ownerName = normalizeText(body.owner_name);
+  const selectedPlan = normalizeText(body.selected_plan);
+  const dealStage = Deno.env.get('AGENDOR_DEAL_STAGE')?.trim();
+  const funnel = Deno.env.get('AGENDOR_FUNNEL')?.trim();
+
+  return compactObject({
+    title: `Novo cadastro - ${businessName}`.slice(0, 150),
+    dealStatusText: 'ongoing',
+    description: [
+      'Negócio criado automaticamente a partir de um cadastro no SalaoPro.',
+      ownerName ? `Responsável: ${ownerName}` : undefined,
+      normalizeText(body.email) ? `Email: ${normalizeText(body.email)}` : undefined,
+      normalizeText(body.phone) ? `Telefone: ${normalizeText(body.phone)}` : undefined,
+      selectedPlan ? `Plano escolhido: ${selectedPlan}` : undefined,
+    ].filter(Boolean).join('\n'),
+    startTime: new Date().toISOString(),
+    dealStage: dealStage ? Number(dealStage) : 1,
+    funnel: funnel ? Number(funnel) : undefined,
+    ownerUser: envValueAsNumberOrString('AGENDOR_OWNER_USER'),
+    allowToAllUsers: true,
+  });
+}
+
+async function findOrganizationByEmail(email: string, apiKey: string) {
+  const searchParams = new URLSearchParams({ email, per_page: '1' });
+  const result = await agendorRequest<Array<{ id?: number }>>(`/organizations?${searchParams.toString()}`, {
+    method: 'GET',
+  }, apiKey);
+
+  return result.data?.[0]?.id;
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
+
+  try {
+    if (req.method !== 'POST') {
+      return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+        status: 405,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const apiKey = Deno.env.get('AGENDOR_API_KEY');
+    if (!apiKey) throw new Error('AGENDOR_API_KEY não configurada');
+
+    const body = (await req.json()) as SignupLeadBody;
+    const businessName = normalizeText(body.business_name);
+    const email = normalizeText(body.email);
+
+    if (!businessName || !email) {
+      return new Response(JSON.stringify({ error: 'Nome do salão e email são obrigatórios' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const organizationPayload = buildOrganizationPayload(body);
+    let organizationId = organizationPayload.cnpj ? undefined : await findOrganizationByEmail(email, apiKey);
+
+    if (!organizationId) {
+      const organizationPath = organizationPayload.cnpj ? '/organizations/upsert' : '/organizations';
+      const organization = await agendorRequest<{ id?: number }>(organizationPath, {
+        method: 'POST',
+        body: JSON.stringify(organizationPayload),
+      }, apiKey);
+
+      organizationId = organization.data?.id;
+    }
+
+    if (!organizationId) {
+      organizationId = await findOrganizationByEmail(email, apiKey);
+    }
+
+    if (!organizationId) {
+      throw new Error('Agendor não retornou o ID da empresa criada');
+    }
+
+    const dealPayload = buildDealPayload(body);
+    const deal = await agendorRequest<{ id?: number }>(`/organizations/${organizationId}/deals`, {
+      method: 'POST',
+      body: JSON.stringify(dealPayload),
+    }, apiKey);
+
+    return new Response(JSON.stringify({
+      ok: true,
+      organization_id: organizationId,
+      deal_id: deal.data?.id ?? null,
+    }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('agendor-create-signup-lead error', error);
+    return new Response(JSON.stringify({ error: (error as Error).message }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+});


### PR DESCRIPTION
### Motivation

- Automatically create or reuse an organization and a deal in Agendor whenever a salon completes signup, using the signup data (salon/business name, owner, email, phone, address, document and selected plan).

### Description

- Added a Supabase Edge Function `supabase/functions/agendor-create-signup-lead/index.ts` that builds organization and deal payloads, upserts or finds an organization in Agendor and creates a new ongoing deal linked to it.  
- Integrated the signup flow in `src/hooks/useAuth.tsx` to invoke the function (`supabase.functions.invoke('agendor-create-signup-lead', ...)`) after a successful `supabase.auth.signUp`, forwarding the signup metadata and `email` without blocking the user-facing success toast.  
- Updated `supabase/config.toml` to declare the function and disable JWT verification for signup calls (`verify_jwt = false`).  
- Documented the integration and required/optional secrets in `README.md` (includes `AGENDOR_API_KEY` and optional `AGENDOR_OWNER_USER`, `AGENDOR_LEAD_ORIGIN`, `AGENDOR_CATEGORY`, `AGENDOR_DEAL_STAGE`, `AGENDOR_FUNNEL`).

### Testing

- Ran TypeScript check with `npx --no-install tsc --noEmit`, which completed successfully.  
- Attempted `npm run lint`, which failed/was blocked due to missing local dependencies in the environment (ESLint packages not installed).  
- Attempted `npm run build` and `npm ci`, both blocked by the environment (missing `vite` / registry access issues), so full lint/build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ac53056148327854fe4375dcdc5f0)