### PR TITLE
Corrige e unifica dashboard do Super Admin

### DIFF
--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -18,7 +18,6 @@ type Profile = {
   id: string;
   created_at: string;
   plan?: string | null;
-  selected_plan_slug?: string | null;
 };
 type Plan = { id: string; name: string; slug: string; monthly_price: number; display_order: number };
 
@@ -30,7 +29,7 @@ export default function AdminDashboard() {
         (supabase as any)
           .from("subscriptions")
           .select("establishment_id, status, monthly_amount, started_at, canceled_at, plan_id, subscription_plans!subscriptions_plan_id_fkey(id, name, slug, monthly_price, display_order)"),
-        (supabase as any).from("profiles").select("id, created_at, plan, selected_plan_slug"),
+        (supabase as any).from("profiles").select("id, created_at, plan"),
         (supabase as any).from("subscription_plans").select("id, name, slug, monthly_price, display_order").order("display_order"),
       ]);
       if (subsError) throw subsError;
@@ -45,7 +44,7 @@ export default function AdminDashboard() {
       });
 
       const getProfilePlan = (profile: Profile) => {
-        const selectedSlug = profile.selected_plan_slug || (profile.plan !== "trial" ? profile.plan : null);
+        const selectedSlug = profile.plan !== "trial" ? profile.plan : null;
         return selectedSlug ? plansBySlug.get(selectedSlug) : undefined;
       };
 

--- a/src/pages/SuperAdmin.tsx
+++ b/src/pages/SuperAdmin.tsx
@@ -9,7 +9,6 @@ import {
   Building2,
   CreditCard,
   Banknote,
-  TrendingUp,
   ShieldAlert,
   Settings as SettingsIcon,
   RefreshCw,
@@ -20,17 +19,15 @@ import AdminSubscriptions from "@/components/admin/AdminSubscriptions";
 import AdminSaaSFinance from "@/components/admin/AdminSaaSFinance";
 import AdminControl from "@/components/admin/AdminControl";
 import AdminPlans from "@/components/admin/AdminPlans";
-import AdminMetrics from "@/components/admin/AdminMetrics";
 import AdminAgendorSync from "@/components/admin/AdminAgendorSync";
 
-type Tab = "dashboard" | "companies" | "subscriptions" | "finance" | "metrics" | "control" | "plans" | "agendor";
+type Tab = "dashboard" | "companies" | "subscriptions" | "finance" | "control" | "plans" | "agendor";
 
 const TABS: { id: Tab; label: string; icon: typeof LayoutDashboard }[] = [
   { id: "dashboard", label: "Dashboard Geral", icon: LayoutDashboard },
   { id: "companies", label: "Empresas", icon: Building2 },
   { id: "subscriptions", label: "Assinaturas", icon: CreditCard },
   { id: "finance", label: "Financeiro SaaS", icon: Banknote },
-  { id: "metrics", label: "Métricas", icon: TrendingUp },
   { id: "control", label: "Controle", icon: ShieldAlert },
   { id: "plans", label: "Planos", icon: SettingsIcon },
   { id: "agendor", label: "Agendor", icon: RefreshCw },
@@ -125,7 +122,6 @@ export default function SuperAdmin() {
       {tab === "companies" && <AdminCompanies />}
       {tab === "subscriptions" && <AdminSubscriptions />}
       {tab === "finance" && <AdminSaaSFinance />}
-      {tab === "metrics" && <AdminMetrics />}
       {tab === "control" && <AdminControl />}
       {tab === "plans" && <AdminPlans />}
       {tab === "agendor" && <AdminAgendorSync />}


### PR DESCRIPTION
### Motivation
- A aba “Métricas” duplicava informações já exibidas em “Dashboard Geral”, causando confusão na UX e potencial falta de manutenção centralizada.
- A query do dashboard dependia do campo `selected_plan_slug` em `profiles`, que nem sempre existe, resultando em KPIs zerados ou falha na montagem dos dados.

### Description
- Remove a aba e importação de `AdminMetrics` em `src/pages/SuperAdmin.tsx` e elimina a opção de tab `metrics` para unificar a visão no `Dashboard Geral`.
- Atualiza a query de `AdminDashboard` em `src/components/admin/AdminDashboard.tsx` para não selecionar `selected_plan_slug` de `profiles` e altera `getProfilePlan` para derivar o plano apenas de `profile.plan` quando aplicável.
- Ajusta o tipo `Profile` para remover `selected_plan_slug` e atualiza as seleções/transformações de dados para preservar os KPIs esperados quando o campo ausente.

### Testing
- `git diff --check` executado e não reportou erros.
- `npm run build` não pôde ser concluído no ambiente devido a `vite: not found` (dependências não instaladas). 
- `npm ci` não pôde ser executado por inconsistência entre `package.json` e `package-lock.json` (lockfile fora de sincronia).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33eb1217bc8327943ddd2c383cf34f)