### PR TITLE
Employee area UI (sidebar, agenda, attendances) and staff email support (DB + functions + UI)

### DIFF
--- a/src/components/EmployeeSidebar.tsx
+++ b/src/components/EmployeeSidebar.tsx
@@ -1,0 +1,71 @@
+import { NavLink, useLocation } from "react-router-dom";
+import { Calendar, LogOut, PlayCircle } from "lucide-react";
+import { Sidebar, SidebarContent, SidebarFooter, SidebarGroup, SidebarGroupContent, SidebarGroupLabel, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem, SidebarSeparator } from "@/components/ui/sidebar";
+import { ThemeToggle } from "@/components/ThemeToggle";
+import { useAuth } from "@/hooks/useAuth";
+
+const employeeItems = [
+  { title: "Agenda", url: "/agenda", icon: Calendar },
+  { title: "Atendimentos", url: "/atendimentos", icon: PlayCircle },
+];
+
+export default function EmployeeSidebar() {
+  const location = useLocation();
+  const { signOut } = useAuth();
+
+  return (
+    <Sidebar className="bg-sidebar text-sidebar-foreground border-r border-sidebar-border" collapsible="offcanvas">
+      <SidebarHeader>
+        <div className="px-3 py-4">
+          <div className="flex items-center gap-2">
+            <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-primary to-accent shadow-[0_0_18px_hsl(var(--primary)/0.5)]" />
+            <div>
+              <div className="text-lg font-bold tracking-tight leading-none">
+                Beauty<span className="bg-gradient-to-r from-primary-glow to-accent bg-clip-text text-transparent">Core</span>
+              </div>
+              <div className="text-[10px] text-sidebar-foreground/50 mt-1 uppercase tracking-wider">Área do funcionário</div>
+            </div>
+          </div>
+        </div>
+      </SidebarHeader>
+
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel className="text-[10px] uppercase tracking-wider font-semibold text-sidebar-foreground/40">Operação</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {employeeItems.map((item) => {
+                const active = location.pathname === item.url;
+                return (
+                  <SidebarMenuItem key={item.title}>
+                    <SidebarMenuButton asChild isActive={active} className={active ? "bg-sidebar-accent text-sidebar-accent-foreground border border-primary/30 shadow-[0_0_18px_hsl(var(--primary)/0.25)] hover:bg-sidebar-accent" : "text-sidebar-foreground/80 hover:bg-sidebar-accent/40 hover:text-sidebar-foreground transition-colors"}>
+                      <NavLink to={item.url} end>
+                        <item.icon className={active ? "text-primary-glow" : ""} />
+                        <span>{item.title}</span>
+                      </NavLink>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                );
+              })}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+
+      <SidebarSeparator />
+      <SidebarFooter>
+        <div className="px-2 pb-2">
+          <ThemeToggle className="w-full border-sidebar-border bg-sidebar text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground" />
+        </div>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton onClick={signOut} className="text-sidebar-foreground/70 hover:bg-destructive/15 hover:text-destructive">
+              <LogOut />
+              <span>Sair</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarFooter>
+    </Sidebar>
+  );
+}

--- a/src/components/agenda/StaffAgendaContent.tsx
+++ b/src/components/agenda/StaffAgendaContent.tsx
@@ -1,0 +1,191 @@
+import { useMemo, useState } from "react";
+import { addDays, endOfDay, format, startOfDay } from "date-fns";
+import { CalendarOff, Clock, Play, RefreshCw, UserX } from "lucide-react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
+import { supabase } from "@/integrations/supabase/client";
+import { useAuth } from "@/hooks/useAuth";
+import { ensureComandaForAppointment } from "@/lib/comanda";
+import { normalizeStatus, STATUS_LABELS, STATUS_VARIANTS } from "@/lib/appointmentStatus";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useToast } from "@/hooks/use-toast";
+
+type Period = "today" | "week" | "next7";
+
+type EmployeeContext = {
+  establishmentId: string | null;
+  professionalId: string | null;
+};
+
+function getRange(period: Period) {
+  const today = new Date();
+  if (period === "today") return { start: startOfDay(today), end: endOfDay(today) };
+  return { start: startOfDay(today), end: endOfDay(addDays(today, 7)) };
+}
+
+export default function EmployeeAgendaContent() {
+  const { user, profile, professionalId: authProfessionalId } = useAuth();
+  const { toast } = useToast();
+  const navigate = useNavigate();
+  const qc = useQueryClient();
+  const [period, setPeriod] = useState<Period>("week");
+  const range = useMemo(() => getRange(period), [period]);
+
+  const contextQuery = useQuery<EmployeeContext>({
+    queryKey: ["employee-agenda-context", user?.id, profile?.id, authProfessionalId],
+    enabled: !!user?.id,
+    queryFn: async () => {
+      if (profile?.id && authProfessionalId) {
+        return { establishmentId: profile.id as string, professionalId: authProfessionalId };
+      }
+
+      const { data, error } = await (supabase as any)
+        .from("establishment_users")
+        .select("establishment_id, professional_id")
+        .eq("user_id", user!.id)
+        .eq("active", true)
+        .maybeSingle();
+
+      if (error) throw error;
+      return {
+        establishmentId: (profile?.id as string | undefined) ?? data?.establishment_id ?? null,
+        professionalId: authProfessionalId ?? data?.professional_id ?? null,
+      };
+    },
+  });
+
+  const establishmentId = contextQuery.data?.establishmentId ?? null;
+  const professionalId = contextQuery.data?.professionalId ?? null;
+
+  const agendaQuery = useQuery({
+    queryKey: ["employee-agenda-data", establishmentId, professionalId, range.start.toISOString(), range.end.toISOString()],
+    enabled: !!establishmentId && !!professionalId,
+    queryFn: async () => {
+      const appointmentsRes = await supabase
+        .from("appointments")
+        .select("id, establishment_id, appointment_date, duration_minutes, service_amount, status, notes, client_id, service_id, professional_id")
+        .eq("establishment_id", establishmentId!)
+        .eq("professional_id", professionalId!)
+        .gte("appointment_date", range.start.toISOString())
+        .lte("appointment_date", range.end.toISOString())
+        .order("appointment_date", { ascending: true });
+
+      if (appointmentsRes.error) throw appointmentsRes.error;
+      const appointments = (appointmentsRes.data ?? []).filter((a: any) => !["canceled", "cancelled"].includes(String(a.status ?? "").toLowerCase()));
+      const clientIds = [...new Set(appointments.map((a: any) => a.client_id).filter(Boolean))];
+      const serviceIds = [...new Set(appointments.map((a: any) => a.service_id).filter(Boolean))];
+
+      const [clientsRes, servicesRes, professionalRes] = await Promise.all([
+        clientIds.length ? supabase.from("clients").select("id, name").eq("establishment_id", establishmentId!).in("id", clientIds) : Promise.resolve({ data: [], error: null }),
+        serviceIds.length ? supabase.from("services").select("id, name, duration_minutes").eq("establishment_id", establishmentId!).in("id", serviceIds) : Promise.resolve({ data: [], error: null }),
+        supabase.from("professionals").select("id, name").eq("establishment_id", establishmentId!).eq("id", professionalId!).maybeSingle(),
+      ]);
+
+      return {
+        appointments,
+        clientMap: new Map((clientsRes.data ?? []).map((c: any) => [c.id, c.name])),
+        serviceMap: new Map((servicesRes.data ?? []).map((s: any) => [s.id, s])),
+        professionalName: (professionalRes.data as any)?.name ?? "Profissional",
+      };
+    },
+  });
+
+  const startService = async (appointment: any) => {
+    try {
+      await supabase.from("appointments").update({ status: "in_service" }).eq("id", appointment.id);
+      await ensureComandaForAppointment({
+        establishment_id: appointment.establishment_id,
+        appointment_id: appointment.id,
+        client_id: appointment.client_id,
+        service_id: appointment.service_id,
+        professional_id: appointment.professional_id,
+      });
+      toast({ title: "Atendimento iniciado", description: "Comanda aberta." });
+      await qc.invalidateQueries({ queryKey: ["employee-agenda-data"] });
+      navigate("/atendimentos");
+    } catch (e: any) {
+      toast({ title: "Erro", description: e.message, variant: "destructive" });
+    }
+  };
+
+  if (contextQuery.isLoading) {
+    return <div className="rounded-md border p-6 bg-card text-sm text-muted-foreground">Carregando vínculo do funcionário...</div>;
+  }
+
+  if (!professionalId) {
+    return (
+      <Card><CardContent className="py-12 text-center text-sm text-muted-foreground">
+        <UserX className="h-10 w-10 mx-auto mb-3 opacity-60" />
+        <div className="font-medium text-foreground">Perfil funcionário sem profissional vinculado</div>
+        <p className="mt-1">Peça para a administração vincular seu usuário a um profissional para visualizar sua agenda e atendimentos.</p>
+      </CardContent></Card>
+    );
+  }
+
+  const appointments = agendaQuery.data?.appointments ?? [];
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-md border bg-card p-4 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <div className="text-sm text-muted-foreground">Área do funcionário</div>
+          <div className="text-sm font-medium">{agendaQuery.data?.professionalName ?? "Seus agendamentos"}</div>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Select value={period} onValueChange={(value) => setPeriod(value as Period)}>
+            <SelectTrigger className="w-[180px]"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="today">Hoje</SelectItem>
+              <SelectItem value="week">Próximos 7 dias</SelectItem>
+              <SelectItem value="next7">Semana</SelectItem>
+            </SelectContent>
+          </Select>
+          <Button variant="outline" onClick={() => agendaQuery.refetch()} disabled={agendaQuery.isFetching}>
+            <RefreshCw className="h-4 w-4 mr-1" /> Atualizar
+          </Button>
+        </div>
+      </div>
+
+      {agendaQuery.isLoading ? (
+        <div className="rounded-md border p-6 bg-card text-sm text-muted-foreground">Carregando seus agendamentos...</div>
+      ) : appointments.length === 0 ? (
+        <Card><CardContent className="py-12 text-center text-sm text-muted-foreground">
+          <CalendarOff className="h-10 w-10 mx-auto mb-3 opacity-60" />
+          Você ainda não possui atendimentos agendados.
+        </CardContent></Card>
+      ) : (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+          {appointments.map((appointment: any) => {
+            const status = normalizeStatus(appointment.status);
+            const service: any = agendaQuery.data?.serviceMap.get(appointment.service_id);
+            return (
+              <Card key={appointment.id}>
+                <CardContent className="p-4 space-y-3">
+                  <div className="flex items-start justify-between gap-2">
+                    <div>
+                      <div className="font-semibold">{agendaQuery.data?.clientMap.get(appointment.client_id) ?? "Cliente"}</div>
+                      <div className="text-sm text-muted-foreground">{service?.name ?? "Serviço"}</div>
+                    </div>
+                    <Badge variant={STATUS_VARIANTS[status] ?? "secondary"}>{STATUS_LABELS[status] ?? "Agendado"}</Badge>
+                  </div>
+                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <Clock className="h-4 w-4" /> {format(new Date(appointment.appointment_date), "dd/MM/yyyy HH:mm")}
+                  </div>
+                  {appointment.notes && <p className="text-sm text-muted-foreground border-t pt-2">{appointment.notes}</p>}
+                  {status !== "in_service" && status !== "completed" && (
+                    <Button className="w-full" onClick={() => startService(appointment)}>
+                      <Play className="h-4 w-4 mr-1" /> Iniciar atendimento
+                    </Button>
+                  )}
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/users/EditUserDialog.tsx
+++ b/src/components/users/EditUserDialog.tsx
@@ -14,6 +14,7 @@ interface UserRow {
   role: "admin" | "employee" | string;
   professional_id?: string | null;
   professional?: { name?: string } | null;
+  email?: string | null;
 }
 
 interface Props {
@@ -36,7 +37,7 @@ export function EditUserDialog({ open, onOpenChange, establishmentId, user }: Pr
     if (!user) return;
     setName(user.professional?.name ?? "");
     setRole((user.role as any) === "admin" ? "admin" : "employee");
-    setEmail("");
+    setEmail(user.email ?? "");
     setPassword("");
   }, [user]);
 
@@ -84,12 +85,12 @@ export function EditUserDialog({ open, onOpenChange, establishmentId, user }: Pr
           </div>
 
           <div>
-            <Label>Novo e-mail (opcional)</Label>
+            <Label>E-mail</Label>
             <Input
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              placeholder="Deixe em branco para manter"
+              placeholder="usuario@exemplo.com"
             />
           </div>
 

--- a/src/pages/StaffAttendances.tsx
+++ b/src/pages/StaffAttendances.tsx
@@ -1,0 +1,179 @@
+import { useEffect, useMemo, useState } from "react";
+import { useAuth } from "@/hooks/useAuth";
+import { supabase } from "@/integrations/supabase/client";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Clock, ShoppingBag, Play, UserX } from "lucide-react";
+import { ComandaSheet } from "@/components/comanda/ComandaSheet";
+
+function elapsed(from: string) {
+  const ms = Date.now() - new Date(from).getTime();
+  const m = Math.floor(ms / 60000);
+  const h = Math.floor(m / 60);
+  return h > 0 ? `${h}h ${m % 60}m` : `${m}m`;
+}
+
+export default function EmployeeAttendances() {
+  const { user, profile, establishmentRole, professionalId } = useAuth();
+  const establishmentIdFromProfile = profile?.id as string | undefined;
+  const isEmployee = establishmentRole === "employee";
+  const contextQuery = useQuery({
+    queryKey: ["employee-attendance-context", user?.id, establishmentIdFromProfile, professionalId],
+    enabled: isEmployee && !!user?.id && (!establishmentIdFromProfile || !professionalId),
+    queryFn: async () => {
+      const { data, error } = await (supabase as any)
+        .from("establishment_users")
+        .select("establishment_id, professional_id")
+        .eq("user_id", user!.id)
+        .eq("active", true)
+        .maybeSingle();
+      if (error) throw error;
+      return data as { establishment_id?: string | null; professional_id?: string | null } | null;
+    },
+  });
+
+  const establishmentId = establishmentIdFromProfile ?? contextQuery.data?.establishment_id ?? undefined;
+  const effectiveProfessionalId = professionalId ?? contextQuery.data?.professional_id ?? null;
+  const effectiveEmployeeWithoutProfessional = isEmployee && !effectiveProfessionalId;
+  const qc = useQueryClient();
+  const [selectedComanda, setSelectedComanda] = useState<string | null>(null);
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => { document.title = "Atendimentos | Beauty Core"; }, []);
+  useEffect(() => { const id = setInterval(() => setTick((t) => t + 1), 30000); return () => clearInterval(id); }, []);
+
+  const { data } = useQuery({
+    queryKey: ["attendances", establishmentId, isEmployee, effectiveProfessionalId],
+    enabled: !!establishmentId && (!isEmployee || !!effectiveProfessionalId),
+    queryFn: async () => {
+      const comandasQuery = supabase
+        .from("comandas")
+        .select("*")
+        .eq("establishment_id", establishmentId!)
+        .in("status", ["open", "awaiting_payment"])
+        .order("opened_at");
+
+      const comandasRes = await comandasQuery;
+      const comandas = comandasRes.data ?? [];
+      const appointmentIds = [...new Set(comandas.map((c: any) => c.appointment_id).filter(Boolean))];
+
+      const [apptsRes, profsRes] = await Promise.all([
+        appointmentIds.length
+          ? supabase.from("appointments").select("id, professional_id, service_id, appointment_date").eq("establishment_id", establishmentId!).in("id", appointmentIds)
+          : Promise.resolve({ data: [], error: null }),
+        isEmployee && effectiveProfessionalId
+          ? supabase.from("professionals").select("id, name").eq("establishment_id", establishmentId!).eq("id", effectiveProfessionalId)
+          : supabase.from("professionals").select("id, name").eq("establishment_id", establishmentId!),
+      ]);
+
+      const apptMap = new Map((apptsRes.data ?? []).map((a: any) => [a.id, a]));
+      const filteredComandas = isEmployee && effectiveProfessionalId
+        ? comandas.filter((c: any) => {
+            if (c.professional_id === effectiveProfessionalId) return true;
+            const appt: any = apptMap.get(c.appointment_id);
+            return appt?.professional_id === effectiveProfessionalId;
+          })
+        : comandas;
+      const clientIds = [...new Set(filteredComandas.map((c: any) => c.client_id).filter(Boolean))];
+      const clientsRes = clientIds.length
+        ? await supabase.from("clients").select("id, name").eq("establishment_id", establishmentId!).in("id", clientIds)
+        : { data: [], error: null };
+
+      const clientMap = new Map((clientsRes.data ?? []).map((c: any) => [c.id, c.name]));
+      const profMap = new Map((profsRes.data ?? []).map((p: any) => [p.id, p.name]));
+      return { comandas: filteredComandas, apptMap, clientMap, profMap };
+    },
+  });
+
+  // Realtime subscription
+  useEffect(() => {
+    if (!establishmentId) return;
+    const channel = supabase
+      .channel("attendances-rt")
+      .on("postgres_changes", { event: "*", schema: "public", table: "comandas" }, () => qc.invalidateQueries({ queryKey: ["attendances"] }))
+      .on("postgres_changes", { event: "*", schema: "public", table: "appointments" }, () => qc.invalidateQueries({ queryKey: ["attendances"] }))
+      .subscribe();
+    return () => { supabase.removeChannel(channel); };
+  }, [establishmentId, qc]);
+
+  const cards = useMemo(() => {
+    if (!data) return [];
+    return data.comandas.map((c: any) => {
+      const appt: any = c.appointment_id ? data.apptMap.get(c.appointment_id) : null;
+      return {
+        ...c,
+        clientName: data.clientMap.get(c.client_id) ?? "Cliente",
+        professionalName: appt ? data.profMap.get(appt.professional_id) : null,
+      };
+    });
+  }, [data, tick]);
+
+  if (!establishmentId) return <div className="p-6 text-sm text-muted-foreground">Carregando...</div>;
+
+  if (effectiveEmployeeWithoutProfessional) {
+    return (
+      <main className="container mx-auto px-4 py-6">
+        <Card><CardContent className="py-12 text-center text-sm text-muted-foreground">
+          <UserX className="h-8 w-8 mx-auto mb-2 opacity-60" />
+          <div className="font-medium text-foreground">Perfil funcionário sem profissional vinculado</div>
+          <p className="mt-1">Peça para a administração vincular seu usuário a um profissional para visualizar seus atendimentos.</p>
+        </CardContent></Card>
+      </main>
+    );
+  }
+
+  return (
+    <main className="container mx-auto px-4 py-6 space-y-6">
+      <header>
+        <h1 className="text-2xl font-bold">Atendimentos em andamento</h1>
+        <p className="text-sm text-muted-foreground">Comandas abertas, prontas para adição de itens e pagamento.</p>
+      </header>
+
+      {cards.length === 0 ? (
+        <Card><CardContent className="py-12 text-center text-sm text-muted-foreground">
+          <ShoppingBag className="h-8 w-8 mx-auto mb-2 opacity-60" />
+          {isEmployee ? "Você ainda não possui atendimentos agendados." : "Nenhum atendimento em andamento."}<br />
+          {!isEmployee && "Inicie um atendimento na Agenda para abrir uma comanda."}
+        </CardContent></Card>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+          {cards.map((c: any) => (
+            <Card key={c.id} className="hover:border-primary transition cursor-pointer" onClick={() => setSelectedComanda(c.id)}>
+              <CardContent className="p-4 space-y-3">
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <div className="font-semibold truncate">{c.clientName}</div>
+                    {c.professionalName && <div className="text-xs text-muted-foreground truncate">com {c.professionalName}</div>}
+                  </div>
+                  <Badge variant={c.status === "awaiting_payment" ? "default" : "secondary"}>
+                    {c.status === "awaiting_payment" ? "Aguard. pagto." : "Em atendimento"}
+                  </Badge>
+                </div>
+                <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <Clock className="h-3 w-3" /> {elapsed(c.opened_at)}
+                </div>
+                <div className="flex items-center justify-between pt-2 border-t">
+                  <div className="text-xs text-muted-foreground">Total</div>
+                  <div className="font-bold text-primary">R$ {Number(c.total ?? 0).toFixed(2)}</div>
+                </div>
+                <Button size="sm" className="w-full" onClick={(e) => { e.stopPropagation(); setSelectedComanda(c.id); }}>
+                  <Play className="h-3.5 w-3.5 mr-1" /> Abrir comanda
+                </Button>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      <ComandaSheet
+        open={!!selectedComanda}
+        onOpenChange={(v) => !v && setSelectedComanda(null)}
+        comandaId={selectedComanda}
+        establishmentId={establishmentId}
+        onClosed={() => qc.invalidateQueries({ queryKey: ["attendances"] })}
+      />
+    </main>
+  );
+}

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -48,7 +48,7 @@ export default function Users() {
     queryFn: async () => {
       const { data, error } = await (supabase as any)
         .from("establishment_users")
-        .select("id, user_id, role, active, professional_id, created_at")
+        .select("id, user_id, role, active, professional_id, email, created_at")
         .eq("establishment_id", establishmentId)
         .order("created_at", { ascending: false });
       if (error) throw error;
@@ -403,6 +403,7 @@ export default function Users() {
               <div>
                 <div className="font-medium">{u.professional?.name ?? "Sem profissional"}</div>
                 <div className="text-sm text-muted-foreground">
+                  {u.email ? `Email: ${u.email} • ` : "Email não disponível • "}
                   Perfil: {u.role === "admin" ? "Administrador" : "Funcionário"} •{" "}
                   {u.active ? "Ativo" : "Bloqueado"}
                 </div>

--- a/supabase/functions/create-staff-user/index.ts
+++ b/supabase/functions/create-staff-user/index.ts
@@ -83,7 +83,7 @@ Deno.serve(async (req) => {
 
     const { error: linkErr } = await adminClient
       .from("establishment_users")
-      .upsert({ establishment_id, user_id: userId, role, professional_id: professional.id, active: true }, { onConflict: "establishment_id,user_id" });
+      .upsert({ establishment_id, user_id: userId, role, professional_id: professional.id, active: true, email: normalizedEmail }, { onConflict: "establishment_id,user_id" });
     if (linkErr) throw linkErr;
 
     return new Response(JSON.stringify({ user_id: userId, professional_id: professional.id }), { headers: { ...CORS, "Content-Type": "application/json" } });

--- a/supabase/functions/update-staff-user/index.ts
+++ b/supabase/functions/update-staff-user/index.ts
@@ -63,7 +63,8 @@ Deno.serve(async (req) => {
     if (mErr || !membership) throw new Error("Usuário não encontrado");
 
     const authUpdates: Record<string, unknown> = {};
-    if (email && String(email).trim()) authUpdates.email = String(email).trim().toLowerCase();
+    const normalizedEmail = email && String(email).trim() ? String(email).trim().toLowerCase() : undefined;
+    if (normalizedEmail) authUpdates.email = normalizedEmail;
     if (password && String(password).length > 0) {
       if (String(password).length < 6) throw new Error("Senha deve ter pelo menos 6 caracteres");
       authUpdates.password = String(password);
@@ -73,10 +74,14 @@ Deno.serve(async (req) => {
       if (aErr) throw aErr;
     }
 
-    if (role && (role === "admin" || role === "employee")) {
+    const membershipUpdates: Record<string, unknown> = {};
+    if (role && (role === "admin" || role === "employee")) membershipUpdates.role = role;
+    if (normalizedEmail) membershipUpdates.email = normalizedEmail;
+
+    if (Object.keys(membershipUpdates).length > 0) {
       const { error: rErr } = await adminClient
         .from("establishment_users")
-        .update({ role })
+        .update(membershipUpdates)
         .eq("id", membership_id);
       if (rErr) throw rErr;
     }

--- a/supabase/migrations/20260701000000_add_email_to_establishment_users.sql
+++ b/supabase/migrations/20260701000000_add_email_to_establishment_users.sql
@@ -1,0 +1,6 @@
+ALTER TABLE public.establishment_users
+ADD COLUMN IF NOT EXISTS email text;
+
+CREATE INDEX IF NOT EXISTS establishment_users_establishment_email_idx
+ON public.establishment_users (establishment_id, lower(email))
+WHERE email IS NOT NULL;


### PR DESCRIPTION
### Motivation

- Provide an employee-focused area with navigation, personal agenda and active attendances so staff can start services and open comandas from the app.
- Persist staff e-mail on membership records so administrators can view and edit contact addresses for staff accounts.

### Description

- Added a new `EmployeeSidebar` component to expose employee navigation links and sign-out/theme toggle via `src/components/EmployeeSidebar.tsx`.
- Implemented the staff agenda component `StaffAgendaContent` which fetches appointments, clients, services and allows starting a service (`src/components/agenda/StaffAgendaContent.tsx`).
- Added the `StaffAttendances` page to list open comandas with realtime subscriptions and a `ComandaSheet` opener (`src/pages/StaffAttendances.tsx`).
- Exposed and allow editing of staff `email` in the UI by updating `EditUserDialog` and `Users` page to query/display the `email` field and adjust placeholders (`src/components/users/EditUserDialog.tsx`, `src/pages/Users.tsx`).
- Backend updates to persist and normalize staff emails by writing the `email` into `establishment_users` in `create-staff-user` and `update-staff-user` functions, plus updating auth via `updateUserById` (`supabase/functions/*`).
- Added a DB migration to add the `email` column and an index to `establishment_users` (`supabase/migrations/20260701000000_add_email_to_establishment_users.sql`).

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43cff5c7f88327b01817a74c867d71)