### PR TITLE
Enable employee operational access and record PDV sale author (created_by_user_id)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,7 @@ import Plans from "./pages/Plans";
 
 const queryClient = new QueryClient();
 
-const employeeAllowedRoutes = new Set(["/agenda", "/atendimentos"]);
+const employeeAllowedRoutes = new Set(["/agenda", "/atendimentos", "/services", "/products", "/sales"]);
 
 function RoleProtectedRoute({ children }: { children: ReactNode }) {
   const { establishmentRole, loading } = useAuth();

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -29,7 +29,7 @@ export default function AppLayout() {
   // Nunca trate role null como owner, pois funcionários chegam com role async durante o login.
   const isOwner = establishmentRole === "owner";
   const isEmployee = establishmentRole === "employee";
-  const employeeAllowedRoutes = new Set(["/agenda", "/atendimentos"]);
+  const employeeAllowedRoutes = new Set(["/agenda", "/atendimentos", "/services", "/products", "/sales"]);
   const storeBlocked = isStoreBlocked(sub);
 
   if (isEmployee && !employeeAllowedRoutes.has(location.pathname)) {

--- a/src/components/EmployeeSidebar.tsx
+++ b/src/components/EmployeeSidebar.tsx
@@ -1,5 +1,5 @@
 import { NavLink, useLocation } from "react-router-dom";
-import { Calendar, LogOut, PlayCircle } from "lucide-react";
+import { Calendar, DollarSign, LogOut, Package, PlayCircle, Scissors } from "lucide-react";
 import { Sidebar, SidebarContent, SidebarFooter, SidebarGroup, SidebarGroupContent, SidebarGroupLabel, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem, SidebarSeparator } from "@/components/ui/sidebar";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { useAuth } from "@/hooks/useAuth";
@@ -7,6 +7,9 @@ import { useAuth } from "@/hooks/useAuth";
 const employeeItems = [
   { title: "Agenda", url: "/agenda", icon: Calendar },
   { title: "Atendimentos", url: "/atendimentos", icon: PlayCircle },
+  { title: "Serviços", url: "/services", icon: Scissors },
+  { title: "Produtos", url: "/products", icon: Package },
+  { title: "Vendas (PDV)", url: "/sales", icon: DollarSign },
 ];
 
 export default function EmployeeSidebar() {

--- a/src/components/agenda/StableAgendaContent.tsx
+++ b/src/components/agenda/StableAgendaContent.tsx
@@ -153,10 +153,6 @@ export default function StableAgendaContent() {
         .eq("active", true)
         .order("name");
 
-      if (isEmployee && professionalId) {
-        query = query.eq("id", professionalId);
-      }
-
       const { data, error } = await query;
       if (error) throw error;
       return (data ?? []) as Professional[];
@@ -269,10 +265,6 @@ export default function StableAgendaContent() {
         .eq("establishment_id", establishmentId)
         .eq("active", true)
         .order("name");
-
-      if (isEmployee && professionalId) {
-        professionalsQuery = professionalsQuery.eq("id", professionalId);
-      }
 
       const blocksQuery = effectiveProfessionalId
         ? (supabase as any)
@@ -453,22 +445,29 @@ export default function StableAgendaContent() {
 
   return (
     <div className="space-y-6">
-      {!isEmployee && <div className="rounded-md border bg-card p-4 flex flex-wrap items-center justify-between gap-3">
-        <div className="min-w-0">
-          <div className="text-sm text-muted-foreground">Link público da agenda</div>
-          <a href={publicLink} className="text-sm font-medium break-all underline underline-offset-4" target="_blank" rel="noreferrer">{publicLink}</a>
-        </div>
+      <div className="rounded-md border bg-card p-4 flex flex-wrap items-center justify-between gap-3">
+        {!isEmployee ? (
+          <div className="min-w-0">
+            <div className="text-sm text-muted-foreground">Link público da agenda</div>
+            <a href={publicLink} className="text-sm font-medium break-all underline underline-offset-4" target="_blank" rel="noreferrer">{publicLink}</a>
+          </div>
+        ) : (
+          <div className="min-w-0">
+            <div className="text-sm text-muted-foreground">Área do funcionário</div>
+            <div className="text-sm font-medium">Você visualiza apenas sua agenda, mas pode criar agendamentos para a loja.</div>
+          </div>
+        )}
         <div className="flex flex-wrap gap-2 items-center">
           <ToggleGroup type="single" value={viewMode} onValueChange={(v) => v && setViewMode(v as any)} variant="outline" size="sm">
             <ToggleGroupItem value="calendar" aria-label="Calendário"><CalendarDays className="h-4 w-4 mr-1" />Calendário</ToggleGroupItem>
             <ToggleGroupItem value="list" aria-label="Lista"><List className="h-4 w-4 mr-1" />Lista</ToggleGroupItem>
           </ToggleGroup>
-          <Button onClick={copyLink} variant="outline">Copiar link</Button>
-          <Button onClick={() => setImportOpen(true)} variant="outline"><Upload className="h-4 w-4 mr-1" /> Importar</Button>
-          <Button onClick={handleNewBlock} variant="outline"><Ban className="h-4 w-4 mr-1" /> Bloquear horário</Button>
+          {!isEmployee && <Button onClick={copyLink} variant="outline">Copiar link</Button>}
+          {!isEmployee && <Button onClick={() => setImportOpen(true)} variant="outline"><Upload className="h-4 w-4 mr-1" /> Importar</Button>}
+          {!isEmployee && <Button onClick={handleNewBlock} variant="outline"><Ban className="h-4 w-4 mr-1" /> Bloquear horário</Button>}
           <Button onClick={handleNew}><Plus className="h-4 w-4 mr-1" /> Novo agendamento</Button>
         </div>
-      </div>}
+      </div>
 
       <div className="rounded-md border bg-card p-4 space-y-4">
         <div className="grid gap-4 md:grid-cols-[minmax(220px,1fr)_220px_minmax(260px,1fr)]">

--- a/src/components/comanda/PdvDialog.tsx
+++ b/src/components/comanda/PdvDialog.tsx
@@ -10,6 +10,7 @@ import { Banknote, Smartphone, CreditCard, ArrowLeftRight, Wallet } from "lucide
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { ClientCreditPrompt } from "@/components/clients/ClientCreditPrompt";
+import { useAuth } from "@/hooks/useAuth";
 
 const methods = [
   { value: "Dinheiro", label: "Dinheiro", icon: Banknote },
@@ -31,6 +32,7 @@ interface Props {
 }
 
 export function PdvDialog({ open, onOpenChange, comanda, items, establishmentId, total, onPaid }: Props) {
+  const { user } = useAuth();
   const [method, setMethod] = useState<typeof methods[number]["value"]>("Dinheiro");
   const [machineId, setMachineId] = useState("");
   const [installments, setInstallments] = useState("2");
@@ -109,6 +111,7 @@ export function PdvDialog({ open, onOpenChange, comanda, items, establishmentId,
   const netTotal = remainingToPay - feeAmount;
 
   const finalize = async () => {
+    if (!user) { toast.error("Faça login para finalizar a venda."); return; }
     if (remainingToPay > 0 && isCard && !machineId) { toast.error("Selecione a maquininha"); return; }
     if (items.length === 0) return;
     if (appliedCredit > availableCredit) { toast.error("Crédito insuficiente"); return; }
@@ -141,6 +144,7 @@ export function PdvDialog({ open, onOpenChange, comanda, items, establishmentId,
           installments: itemCash > 0 ? instNum : null,
           sale_date: new Date().toISOString(),
           payment_method: itemCash > 0 ? method : "Crédito do cliente",
+          created_by_user_id: user.id,
         };
       });
 

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -887,6 +887,7 @@ export type Database = {
           card_machine_id: string | null
           client_id: string
           created_at: string
+          created_by_user_id: string | null
           credit_used: number
           establishment_id: string
           fee_amount: number
@@ -907,6 +908,7 @@ export type Database = {
           card_machine_id?: string | null
           client_id: string
           created_at?: string
+          created_by_user_id?: string | null
           credit_used?: number
           establishment_id: string
           fee_amount?: number
@@ -927,6 +929,7 @@ export type Database = {
           card_machine_id?: string | null
           client_id?: string
           created_at?: string
+          created_by_user_id?: string | null
           credit_used?: number
           establishment_id?: string
           fee_amount?: number
@@ -947,6 +950,13 @@ export type Database = {
             columns: ["appointment_id"]
             isOneToOne: false
             referencedRelation: "appointments"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "sales_created_by_user_id_fkey"
+            columns: ["created_by_user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
             referencedColumns: ["id"]
           },
           {

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -34,7 +34,8 @@ import {
 import { ImportServicesDialog } from '@/components/services/ImportServicesDialog';
 
 const Products = () => {
-  const { user, profile } = useAuth();
+  const { user, profile, establishmentRole } = useAuth();
+  const isEmployee = establishmentRole === 'employee';
   const { toast } = useToast();
   const queryClient = useQueryClient();
 
@@ -153,9 +154,9 @@ const Products = () => {
             <h1 className="text-2xl font-bold">Produtos</h1>
             <p className="text-muted-foreground">Cadastre produtos, preços e controle de estoque</p>
           </div>
-          <Button variant="outline" onClick={() => setImportOpen(true)}>
+          {!isEmployee && <Button variant="outline" onClick={() => setImportOpen(true)}>
             <Upload className="h-4 w-4 mr-2" /> Importar XLSX/CSV
-          </Button>
+          </Button>}
         </div>
       </header>
 
@@ -172,7 +173,7 @@ const Products = () => {
       )}
 
       <main className="container mx-auto px-4 py-8 space-y-8">
-        <Card>
+        {!isEmployee && <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <Plus className="h-5 w-5" /> Cadastrar Produto
@@ -212,7 +213,7 @@ const Products = () => {
               </div>
             </form>
           </CardContent>
-        </Card>
+        </Card>}
 
         <Card>
           <CardHeader>
@@ -232,7 +233,7 @@ const Products = () => {
                     <TableHead>Venda</TableHead>
                     <TableHead>Estoque</TableHead>
                     <TableHead>Status</TableHead>
-                    <TableHead className="text-right">Ações</TableHead>
+                    {!isEmployee && <TableHead className="text-right">Ações</TableHead>}
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -249,7 +250,7 @@ const Products = () => {
                       <TableCell>
                         <Badge variant={p.active ? 'default' : 'outline'}>{p.active ? 'Ativo' : 'Inativo'}</Badge>
                       </TableCell>
-                      <TableCell className="text-right">
+                      {!isEmployee && <TableCell className="text-right">
                         <div className="flex items-center justify-end gap-1">
                           <Button variant="ghost" size="sm" onClick={() => setEditing(p)}>
                             <Pencil className="h-4 w-4" />
@@ -258,7 +259,7 @@ const Products = () => {
                             <Trash2 className="h-4 w-4 text-destructive" />
                           </Button>
                         </div>
-                      </TableCell>
+                      </TableCell>}
                     </TableRow>
                   ))}
                 </TableBody>

--- a/src/pages/Sales.tsx
+++ b/src/pages/Sales.tsx
@@ -348,6 +348,7 @@ export default function Sales() {
           sale_date: new Date().toISOString(),
           payment_method: itemCash > 0 ? paymentMethod : "Crédito do cliente",
           notes: notes || null,
+          created_by_user_id: user.id,
         };
       });
 

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -59,7 +59,8 @@ const formatDurationLabel = (minutes: number | string | null | undefined) => {
 };
 
 const Services = () => {
-  const { user, profile } = useAuth();
+  const { user, profile, establishmentRole } = useAuth();
+  const isEmployee = establishmentRole === 'employee';
   const { toast } = useToast();
   const queryClient = useQueryClient();
 
@@ -345,9 +346,9 @@ const Services = () => {
               <p className="text-muted-foreground">Cadastre e gerencie seus serviços e valores</p>
             </div>
           </div>
-          <Button variant="outline" onClick={() => setImportOpen(true)}>
+          {!isEmployee && <Button variant="outline" onClick={() => setImportOpen(true)}>
             <Upload className="h-4 w-4 mr-2" /> Importar XLSX/CSV
-          </Button>
+          </Button>}
         </div>
       </header>
 
@@ -364,7 +365,7 @@ const Services = () => {
       {/* Content */}
       <main className="container mx-auto px-4 py-8 space-y-8">
         {/* Create Service */}
-        <Card>
+        {!isEmployee && <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <Plus className="h-5 w-5" />
@@ -409,7 +410,7 @@ const Services = () => {
               </div>
             </form>
           </CardContent>
-        </Card>
+        </Card>}
 
         {/* Services List */}
         <Card>
@@ -453,7 +454,7 @@ const Services = () => {
                     <TableHead>Duração</TableHead>
                     <TableHead>Comissão</TableHead>
                     <TableHead>Status</TableHead>
-                    <TableHead className="text-right">Ações</TableHead>
+                    {!isEmployee && <TableHead className="text-right">Ações</TableHead>}
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -464,7 +465,7 @@ const Services = () => {
                       <TableCell>{formatDurationLabel(s.duration_minutes)}</TableCell>
                       <TableCell>{Number(s.commission_solo ?? 0)}%</TableCell>
                       <TableCell>{s.active ? 'Ativo' : 'Inativo'}</TableCell>
-                      <TableCell className="text-right">
+                      {!isEmployee && <TableCell className="text-right">
                         <div className="flex items-center justify-end gap-1">
                           <Button variant="ghost" size="icon" onClick={() => setEditingService({ ...s, duration_minutes: formatDurationInput(s.duration_minutes) })}>
                             <Pencil className="h-4 w-4" />
@@ -473,7 +474,7 @@ const Services = () => {
                             <Trash2 className="h-4 w-4 text-destructive" />
                           </Button>
                         </div>
-                      </TableCell>
+                      </TableCell>}
                     </TableRow>
                   ))}
                 </TableBody>
@@ -485,7 +486,7 @@ const Services = () => {
         {/* Profissionais agora são gerenciados na aba Usuários */}
 
         {/* Vincular Serviço x Profissional */}
-        <Card>
+        {!isEmployee && <Card>
           <CardHeader>
             <CardTitle>Vincular Serviço a Profissional</CardTitle>
             <CardDescription>Escolha um serviço e um profissional para vincular</CardDescription>
@@ -554,7 +555,7 @@ const Services = () => {
               </Table>
             </div>
           </CardContent>
-        </Card>
+        </Card>}
         {/* Edit Service Dialog */}
         <Dialog open={!!editingService} onOpenChange={(open) => { if (!open) setEditingService(null); }}>
           <DialogContent className="max-w-lg">

--- a/src/pages/StableAgenda.tsx
+++ b/src/pages/StableAgenda.tsx
@@ -2,10 +2,9 @@ import { useEffect } from "react";
 import { useAuth } from "@/hooks/useAuth";
 import { Navigate } from "react-router-dom";
 import StableAgendaContent from "@/components/agenda/StableAgendaContent";
-import EmployeeAgendaContent from "@/components/agenda/EmployeeAgendaContent";
 
 export default function StableAgenda() {
-  const { user, establishmentRole } = useAuth();
+  const { user } = useAuth();
 
   useEffect(() => {
     document.title = "Agenda | Beauty Core";
@@ -26,7 +25,7 @@ export default function StableAgenda() {
         </div>
       </header>
       <main className="container mx-auto px-4 py-10 space-y-6">
-        {establishmentRole === "employee" ? <EmployeeAgendaContent /> : <StableAgendaContent />}
+        <StableAgendaContent />
       </main>
     </div>
   );

--- a/supabase/migrations/20260701233000_employee_operational_permissions_and_sale_audit.sql
+++ b/supabase/migrations/20260701233000_employee_operational_permissions_and_sale_audit.sql
@@ -1,0 +1,63 @@
+-- Allow employees to perform operational tasks without granting administrative access.
+
+ALTER TABLE public.sales
+  ADD COLUMN IF NOT EXISTS created_by_user_id uuid REFERENCES auth.users(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_sales_created_by_user_id ON public.sales(created_by_user_id);
+
+-- Employees can create appointments for the establishment. Existing SELECT policies/RPCs still
+-- restrict what an employee sees in the agenda to their linked professional.
+DROP POLICY IF EXISTS "Staff can create establishment appointments" ON public.appointments;
+CREATE POLICY "Staff can create establishment appointments"
+  ON public.appointments FOR INSERT TO authenticated
+  WITH CHECK (
+    establishment_id = public.current_establishment_id()
+    AND public.current_establishment_role() IN ('owner', 'admin', 'employee')
+  );
+
+DROP POLICY IF EXISTS "Staff can create appointment_services" ON public.appointment_services;
+CREATE POLICY "Staff can create appointment_services"
+  ON public.appointment_services FOR INSERT TO authenticated
+  WITH CHECK (
+    establishment_id = public.current_establishment_id()
+    AND public.current_establishment_role() IN ('owner', 'admin', 'employee')
+  );
+
+DROP POLICY IF EXISTS "Staff can create appointment_professionals" ON public.appointment_professionals;
+CREATE POLICY "Staff can create appointment_professionals"
+  ON public.appointment_professionals FOR INSERT TO authenticated
+  WITH CHECK (
+    establishment_id = public.current_establishment_id()
+    AND public.current_establishment_role() IN ('owner', 'admin', 'employee')
+  );
+
+-- PDV dependencies: employees can read the active payment setup needed to complete a sale.
+DROP POLICY IF EXISTS "Staff can view card machines" ON public.card_machines;
+CREATE POLICY "Staff can view card machines"
+  ON public.card_machines FOR SELECT TO authenticated
+  USING (public.is_establishment_member(establishment_id, auth.uid()));
+
+DROP POLICY IF EXISTS "Staff can view card machine fees" ON public.card_machine_fees;
+CREATE POLICY "Staff can view card machine fees"
+  ON public.card_machine_fees FOR SELECT TO authenticated
+  USING (public.is_establishment_member(establishment_id, auth.uid()));
+
+-- Employees can launch sales for the establishment even when the sold professional differs
+-- from the authenticated employee. The created_by_user_id audit field must always be the
+-- authenticated user for direct client inserts.
+DROP POLICY IF EXISTS "Staff can create establishment sales" ON public.sales;
+CREATE POLICY "Staff can create establishment sales"
+  ON public.sales FOR INSERT TO authenticated
+  WITH CHECK (
+    establishment_id = public.current_establishment_id()
+    AND public.current_establishment_role() IN ('owner', 'admin', 'employee')
+    AND created_by_user_id = auth.uid()
+  );
+
+DROP POLICY IF EXISTS "Staff can create sale_professionals" ON public.sale_professionals;
+CREATE POLICY "Staff can create sale_professionals"
+  ON public.sale_professionals FOR INSERT TO authenticated
+  WITH CHECK (
+    establishment_id = public.current_establishment_id()
+    AND public.current_establishment_role() IN ('owner', 'admin', 'employee')
+  );


### PR DESCRIPTION
### Motivation
- Permitir que usuários com perfil `employee` realizem tarefas operacionais (criar agendamentos, acessar catálogo mínimo e lançar vendas no PDV) sem conceder acesso administrativo completo. 
- Garantir auditoria das vendas registrando qual usuário autenticado realizou cada lançamento no PDV. 
- Manter as restrições administrativas (relatórios, configurações, gestão de usuários, etc.) para perfis `admin/owner` apenas.

### Description
- Adicionada migration `supabase/migrations/20260701233000_employee_operational_permissions_and_sale_audit.sql` que cria a coluna auditável `created_by_user_id` em `public.sales`, índice e políticas RLS para permitir criação de `appointments`, `appointment_services`, `appointment_professionals`, leitura de `card_machines`/`card_machine_fees` e inserção de `sales`/`sale_professionals` por staff quando aplicável. 
- Frontend: liberadas rotas operacionais para funcionários ajustando `employeeAllowedRoutes` em `src/App.tsx` e `src/components/AppLayout.tsx`, e adicionado acesso a `Serviços`, `Produtos` e `Vendas` no menu de `EmployeeSidebar`. 
- PDV e vendas: salvamento do ID do usuário autenticado ao criar vendas via PDV e tela de vendas adicionando `created_by_user_id` em `src/pages/Sales.tsx` e `src/components/comanda/PdvDialog.tsx`, além da tipagem correspondente em `src/integrations/supabase/types.ts`. 
- Agenda e UX: mantida a visualização da agenda do funcionário limitada ao profissional vinculado, porém a interface de agenda (`StableAgendaContent`) permite que funcionários criem novos agendamentos respeitando validações de disponibilidade, bloqueios e horário de funcionamento; controles administrativos de import/creação/edição/exclusão em `Products` e `Services` foram ocultados para `employee`. 

### Testing
- Executado `git diff --check` sem problemas detectados. 
- Verificada presença do binário local do build com `test -x node_modules/.bin/vite; echo vite_bin:$?` que retornou `vite_bin:1` indicando que o binário local do Vite não está disponível no ambiente. 
- Tentativa de build com `npm run build` foi bloqueada pelo ambiente com `sh: 1: vite: not found`. 
- Tentativa de instalar dependências (`npm install`) foi bloqueada pela registry com um `403 Forbidden` ao buscar `@supabase/supabase-js`, portanto validação de build/integração está pendente até corrigir o ambiente de CI/local.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45a1f9a76483278770504f84c2e4a4)