### PR TITLE
Adiciona campo de auditoria `created_by_user_id` em `sales` e atualiza tipos

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -887,6 +887,7 @@ export type Database = {
           card_machine_id: string | null
           client_id: string
           created_at: string
+          created_by_user_id: string | null
           credit_used: number
           establishment_id: string
           fee_amount: number
@@ -907,6 +908,7 @@ export type Database = {
           card_machine_id?: string | null
           client_id: string
           created_at?: string
+          created_by_user_id?: string | null
           credit_used?: number
           establishment_id: string
           fee_amount?: number
@@ -927,6 +929,7 @@ export type Database = {
           card_machine_id?: string | null
           client_id?: string
           created_at?: string
+          created_by_user_id?: string | null
           credit_used?: number
           establishment_id?: string
           fee_amount?: number
@@ -947,6 +950,13 @@ export type Database = {
             columns: ["appointment_id"]
             isOneToOne: false
             referencedRelation: "appointments"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "sales_created_by_user_id_fkey"
+            columns: ["created_by_user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
             referencedColumns: ["id"]
           },
           {

--- a/supabase/migrations/20260704120000_ensure_sales_created_by_user_id.sql
+++ b/supabase/migrations/20260704120000_ensure_sales_created_by_user_id.sql
@@ -1,0 +1,32 @@
+-- Ensure sales records carry the authenticated user who launched the sale.
+-- This migration is intentionally idempotent because older environments may have
+-- code already sending created_by_user_id before the database/schema cache has
+-- the column available.
+
+ALTER TABLE public.sales
+  ADD COLUMN IF NOT EXISTS created_by_user_id uuid;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'sales_created_by_user_id_fkey'
+      AND conrelid = 'public.sales'::regclass
+  ) THEN
+    ALTER TABLE public.sales
+      ADD CONSTRAINT sales_created_by_user_id_fkey
+      FOREIGN KEY (created_by_user_id)
+      REFERENCES auth.users(id)
+      ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_sales_created_by_user_id
+  ON public.sales(created_by_user_id);
+
+COMMENT ON COLUMN public.sales.created_by_user_id IS
+  'Authenticated user that created/launched the sale, including PDV and attendance checkout flows.';
+
+-- Ask PostgREST/Supabase API to refresh its schema cache after the column is added.
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
### Motivation
- Corrigir o erro de cache de schema ao criar vendas a partir de atendimentos, garantindo que o campo de auditoria do usuário exista no banco para que inserts contendo `created_by_user_id` não quebrem o PostgREST/Supabase schema cache. 
- Habilitar rastreamento consistente do usuário que criou a venda tanto no PDV quanto no checkout de atendimentos, compatível com as políticas RLS já previstas.

### Description
- Adiciona migration idempotente `supabase/migrations/20260704120000_ensure_sales_created_by_user_id.sql` que cria a coluna `created_by_user_id` em `public.sales`, adiciona FK para `auth.users(id)`, cria índice, inclui comentário de coluna e emite `NOTIFY pgrst, 'reload schema'` para forçar o refresh do schema cache.
- Atualiza os tipos gerados em `src/integrations/supabase/types.ts` para incluir `created_by_user_id` nas definições `Row`, `Insert`, `Update` e adiciona o relacionamento com `users`.
- Não foi necessário alterar a lógica de PDV/atendimento para enviar o campo, pois as rotas de criação de venda no PDV (`src/pages/Sales.tsx`) e no checkout de comanda (`src/components/comanda/PdvDialog.tsx`) já populam `created_by_user_id: user.id`.
- A alteração é compatível com as políticas RLS existentes que exigem `created_by_user_id = auth.uid()` para inserções de funcionários.

### Testing
- Executei a build do frontend com `npm run build` e o processo concluiu com sucesso.
- Rodei `npm run lint`; o lint foi executado mas falhou devido a problemas pré-existentes no repositório (muitos `@typescript-eslint/no-explicit-any`, regras de hooks e estilo), os quais não foram introduzidos por esta alteração.
- Verifiquei manualmente que os pontos de inserção de venda (PDV e comanda) já setam `created_by_user_id`, e a migration garante que ambientes sem a coluna não apresentem mais o erro de schema cache ao receber esse campo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49455bc7b0832787d63676ac28280d)