### PR TITLE
Ensure `sales.created_by_user_id` exists and add resilient insert fallback

### DIFF
--- a/src/components/comanda/PdvDialog.tsx
+++ b/src/components/comanda/PdvDialog.tsx
@@ -11,6 +11,7 @@ import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { ClientCreditPrompt } from "@/components/clients/ClientCreditPrompt";
 import { useAuth } from "@/hooks/useAuth";
+import { insertSalesWithCreatorFallback } from "@/lib/salesInsert";
 
 const methods = [
   { value: "Dinheiro", label: "Dinheiro", icon: Banknote },
@@ -148,7 +149,7 @@ export function PdvDialog({ open, onOpenChange, comanda, items, establishmentId,
         };
       });
 
-      const { data: insertedSales, error } = await supabase.from("sales").insert(salesPayload).select("id, service_id, amount, credit_used");
+      const { data: insertedSales, error } = await insertSalesWithCreatorFallback(salesPayload);
       if (error) throw error;
 
       // Aplica débito de crédito por venda (mantém histórico vinculado ao sale_id para estorno em cancelamento)

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -887,6 +887,7 @@ export type Database = {
           card_machine_id: string | null
           client_id: string
           created_at: string
+          created_by_user_id: string | null
           credit_used: number
           establishment_id: string
           fee_amount: number
@@ -907,6 +908,7 @@ export type Database = {
           card_machine_id?: string | null
           client_id: string
           created_at?: string
+          created_by_user_id?: string | null
           credit_used?: number
           establishment_id: string
           fee_amount?: number
@@ -927,6 +929,7 @@ export type Database = {
           card_machine_id?: string | null
           client_id?: string
           created_at?: string
+          created_by_user_id?: string | null
           credit_used?: number
           establishment_id?: string
           fee_amount?: number
@@ -947,6 +950,13 @@ export type Database = {
             columns: ["appointment_id"]
             isOneToOne: false
             referencedRelation: "appointments"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "sales_created_by_user_id_fkey"
+            columns: ["created_by_user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
             referencedColumns: ["id"]
           },
           {

--- a/src/lib/salesInsert.ts
+++ b/src/lib/salesInsert.ts
@@ -1,0 +1,33 @@
+import { supabase } from "@/integrations/supabase/client";
+
+type SaleInsertPayload = Record<string, unknown>;
+
+const isMissingCreatedByUserIdSchemaError = (error: unknown) => {
+  if (!error || typeof error !== "object") return false;
+  const maybeError = error as { code?: string; message?: string };
+  return (
+    maybeError.code === "PGRST204" &&
+    typeof maybeError.message === "string" &&
+    maybeError.message.includes("created_by_user_id") &&
+    maybeError.message.includes("schema cache")
+  );
+};
+
+const withoutCreatedByUserId = (payload: SaleInsertPayload[]) =>
+  payload.map(({ created_by_user_id: _createdByUserId, ...sale }) => sale);
+
+export const insertSalesWithCreatorFallback = async (payload: SaleInsertPayload[]) => {
+  const insertSales = (salesPayload: SaleInsertPayload[]) =>
+    supabase.from("sales").insert(salesPayload).select("id, service_id, amount, credit_used");
+
+  const result = await insertSales(payload);
+
+  if (!result.error || !isMissingCreatedByUserIdSchemaError(result.error)) {
+    return result;
+  }
+
+  // Some deployed databases still need the sales.created_by_user_id migration or a
+  // PostgREST schema refresh. Retry without the audit column so the checkout is not
+  // blocked; migrated environments continue to record the authenticated creator above.
+  return insertSales(withoutCreatedByUserId(payload));
+};

--- a/src/pages/Sales.tsx
+++ b/src/pages/Sales.tsx
@@ -35,6 +35,7 @@ import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { ClientCombobox } from "@/components/ClientCombobox";
 import { ClientCreditPrompt } from "@/components/clients/ClientCreditPrompt";
+import { insertSalesWithCreatorFallback } from "@/lib/salesInsert";
 import { Wallet } from "lucide-react";
 
 interface SimpleClient { id: string; name: string }
@@ -352,10 +353,7 @@ export default function Sales() {
         };
       });
 
-      const { data: insertedSales, error } = await supabase
-        .from("sales")
-        .insert(salesPayload)
-        .select("id, service_id, amount, credit_used");
+      const { data: insertedSales, error } = await insertSalesWithCreatorFallback(salesPayload);
       if (error) throw error;
 
       // Debita o crédito por venda (vinculado para estorno em cancelamento)

--- a/supabase/migrations/20260704120000_ensure_sales_created_by_user_id.sql
+++ b/supabase/migrations/20260704120000_ensure_sales_created_by_user_id.sql
@@ -1,0 +1,32 @@
+-- Ensure sales records carry the authenticated user who launched the sale.
+-- This migration is intentionally idempotent because older environments may have
+-- code already sending created_by_user_id before the database/schema cache has
+-- the column available.
+
+ALTER TABLE public.sales
+  ADD COLUMN IF NOT EXISTS created_by_user_id uuid;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'sales_created_by_user_id_fkey'
+      AND conrelid = 'public.sales'::regclass
+  ) THEN
+    ALTER TABLE public.sales
+      ADD CONSTRAINT sales_created_by_user_id_fkey
+      FOREIGN KEY (created_by_user_id)
+      REFERENCES auth.users(id)
+      ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_sales_created_by_user_id
+  ON public.sales(created_by_user_id);
+
+COMMENT ON COLUMN public.sales.created_by_user_id IS
+  'Authenticated user that created/launched the sale, including PDV and attendance checkout flows.';
+
+-- Ask PostgREST/Supabase API to refresh its schema cache after the column is added.
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
### Motivation
- Fix the error caused when the frontend sends `created_by_user_id` to a Supabase/PostgREST instance whose schema cache still doesn't recognise the new column. 
- Ensure sales keep an audit of the authenticated user who launched the sale (PDV and attendance/checkout flows). 
- Avoid blocking the checkout flow while migrations or schema refreshes propagate to deployed environments. 

### Description
- Add idempotent migration `supabase/migrations/20260704120000_ensure_sales_created_by_user_id.sql` to create `sales.created_by_user_id` with FK to `auth.users(id)`, index, column comment and a `NOTIFY pgrst, 'reload schema'` to prompt schema cache refresh. 
- Update generated Supabase types in `src/integrations/supabase/types.ts` to include `created_by_user_id` in `Row`, `Insert`, `Update` and the relationship to `users`. 
- Add a resilient helper `src/lib/salesInsert.ts` (`insertSalesWithCreatorFallback`) that inserts sales normally but detects the specific `PGRST204` schema-cache error mentioning `created_by_user_id` and retries the insert without that field. 
- Wire the helper into the PDV and sales checkout code by replacing direct inserts with calls in `src/components/comanda/PdvDialog.tsx` and `src/pages/Sales.tsx`, preserving `created_by_user_id: user.id` in payloads for migrated environments. 

### Testing
- Ran `npm run build` (Vite production build) and it completed successfully. 
- Ran `npm run lint` (`eslint .`) and it executed but failed due to pre-existing repository-wide lint errors (many `@typescript-eslint/no-explicit-any`, hooks and style issues) unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49455bc7b0832787d63676ac28280d)