### PR TITLE
Adicionar recorrências financeiras para Contas a Pagar/Receber

### DIFF
--- a/src/components/reports/CashFlowReport.tsx
+++ b/src/components/reports/CashFlowReport.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
@@ -10,12 +11,24 @@ import { Textarea } from "@/components/ui/textarea";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { KpiCard, currencyBRL } from "./KpiCard";
-import { ArrowDownCircle, ArrowUpCircle, Scale, TrendingUp, Plus } from "lucide-react";
+import { ArrowDownCircle, ArrowUpCircle, Scale, TrendingUp, Plus, Repeat } from "lucide-react";
 import { format } from "date-fns";
 import { toast } from "@/hooks/use-toast";
+import { Switch } from "@/components/ui/switch";
 import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, BarChart, Bar, Legend } from "recharts";
 
 interface Props { establishmentId: string; startDate: Date; endDate: Date; }
+
+const RECURRENCE_FREQUENCIES = [
+  { value: "daily", label: "Diário" },
+  { value: "weekly", label: "Semanal" },
+  { value: "biweekly", label: "Quinzenal" },
+  { value: "monthly", label: "Mensal" },
+  { value: "bimonthly", label: "Bimestral" },
+  { value: "quarterly", label: "Trimestral" },
+  { value: "semiannual", label: "Semestral" },
+  { value: "annual", label: "Anual" },
+];
 
 const PAYMENT_OPTIONS = ["dinheiro", "pix", "cartão de crédito", "cartão de débito", "transferência", "boleto", "outro"];
 
@@ -25,6 +38,7 @@ export function CashFlowReport({ establishmentId, startDate, endDate }: Props) {
   const qc = useQueryClient();
 
   const [open, setOpen] = useState(false);
+  const [recurringFilter, setRecurringFilter] = useState<"all" | "recurring" | "single">("all");
   const [form, setForm] = useState({
     entry_type: "income" as "income" | "expense",
     description: "",
@@ -33,15 +47,21 @@ export function CashFlowReport({ establishmentId, startDate, endDate }: Props) {
     payment_method: "dinheiro",
     notes: "",
     entry_date: format(new Date(), "yyyy-MM-dd'T'HH:mm"),
+    recurring: false,
+    frequency: "monthly",
+    end_mode: "never" as "never" | "date" | "count",
+    end_date: "",
+    max_occurrences: "",
   });
 
   const { data, isLoading } = useQuery({
-    queryKey: ["reports", "cash-flow", establishmentId, startISO, endISO],
+    queryKey: ["reports", "cash-flow", establishmentId, startISO, endISO, recurringFilter],
     queryFn: async () => {
       const { data: rows, error } = await supabase
         .from("cash_flow_entries")
         .select("*")
         .eq("establishment_id", establishmentId)
+        .is("deleted_at", null)
         .gte("entry_date", startISO).lte("entry_date", endISO)
         .order("entry_date", { ascending: false });
       if (error) throw error;
@@ -75,7 +95,8 @@ export function CashFlowReport({ establishmentId, startDate, endDate }: Props) {
       }
       const methods = Array.from(byMethod.entries()).map(([name, value]) => ({ name, value }));
 
-      return { rows: list, income, expense, balance, series, methods };
+      const filteredRows = recurringFilter === "recurring" ? list.filter((r: any) => r.recurring_plan_id) : recurringFilter === "single" ? list.filter((r: any) => !r.recurring_plan_id) : list;
+      return { rows: filteredRows, income, expense, balance, series, methods };
     },
   });
 
@@ -85,7 +106,19 @@ export function CashFlowReport({ establishmentId, startDate, endDate }: Props) {
       toast({ title: "Preencha descrição e valor válido", variant: "destructive" });
       return;
     }
-    const { error } = await supabase.from("cash_flow_entries").insert({
+    const template = { description: form.description.trim(), amount: amt, category: form.category || (form.entry_type === "income" ? "Entrada manual" : "Saída manual"), payment_method: form.payment_method, notes: form.notes || null };
+    const { error } = form.recurring
+      ? await supabase.rpc("create_financial_recurrence" as never, {
+          p_tenant_id: establishmentId,
+          p_tipo: form.entry_type === "income" ? "receivable" : "payable",
+          p_frequency: form.frequency,
+          p_start_date: form.entry_date.slice(0, 10),
+          p_end_date: form.end_mode === "date" && form.end_date ? form.end_date : null,
+          p_max_occurrences: form.end_mode === "count" && form.max_occurrences ? Number(form.max_occurrences) : null,
+          p_template: template,
+          p_generate_until: form.end_mode === "never" ? format(new Date(new Date(form.entry_date).getFullYear() + 1, new Date(form.entry_date).getMonth(), new Date(form.entry_date).getDate()), "yyyy-MM-dd") : null,
+        } as never)
+      : await supabase.from("cash_flow_entries").insert({
       establishment_id: establishmentId,
       entry_type: form.entry_type,
       description: form.description.trim(),
@@ -100,7 +133,7 @@ export function CashFlowReport({ establishmentId, startDate, endDate }: Props) {
     if (error) { toast({ title: "Erro ao lançar", description: error.message, variant: "destructive" }); return; }
     toast({ title: "Lançamento criado" });
     setOpen(false);
-    setForm({ ...form, description: "", amount: "", category: "", notes: "" });
+    setForm({ ...form, description: "", amount: "", category: "", notes: "", recurring: false, end_mode: "never", end_date: "", max_occurrences: "" });
     qc.invalidateQueries({ queryKey: ["reports", "cash-flow"] });
   };
 
@@ -109,7 +142,7 @@ export function CashFlowReport({ establishmentId, startDate, endDate }: Props) {
       toast({ title: "Não é possível excluir", description: "Lançamentos automáticos devem ser removidos na origem (venda/despesa)." });
       return;
     }
-    const { error } = await supabase.from("cash_flow_entries").delete().eq("id", id);
+    const { error } = await supabase.from("cash_flow_entries").update({ deleted_at: new Date().toISOString() }).eq("id", id);
     if (error) { toast({ title: "Erro", description: error.message, variant: "destructive" }); return; }
     qc.invalidateQueries({ queryKey: ["reports", "cash-flow"] });
   };
@@ -120,7 +153,10 @@ export function CashFlowReport({ establishmentId, startDate, endDate }: Props) {
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between gap-3 flex-wrap">
-        <h2 className="text-lg font-semibold">Fluxo de caixa</h2>
+        <div className="flex items-center gap-2">
+          <h2 className="text-lg font-semibold">Fluxo de caixa</h2>
+          <Select value={recurringFilter} onValueChange={(v: any) => setRecurringFilter(v)}><SelectTrigger className="w-[210px]"><SelectValue /></SelectTrigger><SelectContent><SelectItem value="all">Todas</SelectItem><SelectItem value="recurring">Apenas recorrentes</SelectItem><SelectItem value="single">Apenas não recorrentes</SelectItem></SelectContent></Select>
+        </div>
         <Dialog open={open} onOpenChange={setOpen}>
           <DialogTrigger asChild>
             <Button size="sm" className="gap-2"><Plus className="h-4 w-4" /> Novo lançamento</Button>
@@ -166,6 +202,20 @@ export function CashFlowReport({ establishmentId, startDate, endDate }: Props) {
               <div>
                 <Label>Categoria (opcional)</Label>
                 <Input value={form.category} onChange={(e) => setForm({ ...form, category: e.target.value })} placeholder="Ex: Aporte, Compra emergencial…" />
+              </div>
+              <div className="rounded-md border p-3 space-y-3">
+                <div className="flex items-center justify-between gap-3">
+                  <Label htmlFor="recurring-cash-flow">Lançamento recorrente</Label>
+                  <Switch id="recurring-cash-flow" checked={form.recurring} onCheckedChange={(v) => setForm({ ...form, recurring: v })} />
+                </div>
+                {form.recurring && (
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                    <div><Label>Frequência</Label><Select value={form.frequency} onValueChange={(v) => setForm({ ...form, frequency: v })}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent>{RECURRENCE_FREQUENCIES.map((f) => <SelectItem key={f.value} value={f.value}>{f.label}</SelectItem>)}</SelectContent></Select></div>
+                    <div><Label>Encerramento</Label><Select value={form.end_mode} onValueChange={(v: any) => setForm({ ...form, end_mode: v })}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent><SelectItem value="never">Recorrência infinita</SelectItem><SelectItem value="date">Até uma data</SelectItem><SelectItem value="count">Quantidade</SelectItem></SelectContent></Select></div>
+                    {form.end_mode === "date" && <div><Label>Data final</Label><Input type="date" value={form.end_date} onChange={(e) => setForm({ ...form, end_date: e.target.value })} /></div>}
+                    {form.end_mode === "count" && <div><Label>Gerar ocorrências</Label><Input type="number" min="1" placeholder="12, 24, 60..." value={form.max_occurrences} onChange={(e) => setForm({ ...form, max_occurrences: e.target.value })} /></div>}
+                  </div>
+                )}
               </div>
               <div>
                 <Label>Observações</Label>
@@ -270,10 +320,10 @@ export function CashFlowReport({ establishmentId, startDate, endDate }: Props) {
                     </Badge>
                   </TableCell>
                   <TableCell><Badge variant="secondary">{r.category ?? "—"}</Badge></TableCell>
-                  <TableCell className="font-medium">{r.description}</TableCell>
+                  <TableCell className="font-medium"><div className="flex items-center gap-2">{r.description}{r.recurring_plan_id && <Badge variant="outline" className="gap-1"><Repeat className="h-3 w-3" /> Recorrente</Badge>}</div></TableCell>
                   <TableCell className="capitalize">{r.payment_method ?? "—"}</TableCell>
                   <TableCell>
-                    <Badge variant="outline" className="capitalize">{r.source === "sale" ? "Venda" : r.source === "expense" ? "Despesa" : "Manual"}</Badge>
+                    <Badge variant="outline" className="capitalize">{r.source === "sale" ? "Venda" : r.source === "expense" ? "Despesa" : r.source === "recurrence" ? "Recorrência" : "Manual"}</Badge>
                   </TableCell>
                   <TableCell className={"text-right font-semibold " + (isIn ? "text-emerald-600 dark:text-emerald-400" : "text-destructive")}>
                     {isIn ? "+ " : "- "}{currencyBRL(Number(r.amount))}

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -323,6 +323,9 @@ export type Database = {
           id: string
           notes: string | null
           payment_method: string | null
+          recurring_plan_id: string | null
+          occurrence_date: string | null
+          deleted_at: string | null
           source: string
           source_id: string | null
           status: string
@@ -339,6 +342,9 @@ export type Database = {
           id?: string
           notes?: string | null
           payment_method?: string | null
+          recurring_plan_id?: string | null
+          occurrence_date?: string | null
+          deleted_at?: string | null
           source?: string
           source_id?: string | null
           status?: string
@@ -355,6 +361,9 @@ export type Database = {
           id?: string
           notes?: string | null
           payment_method?: string | null
+          recurring_plan_id?: string | null
+          occurrence_date?: string | null
+          deleted_at?: string | null
           source?: string
           source_id?: string | null
           status?: string
@@ -655,6 +664,10 @@ export type Database = {
           expense_date: string
           id: string
           notes: string | null
+          recurring_plan_id: string | null
+          occurrence_date: string | null
+          deleted_at: string | null
+          status: string
           updated_at: string
         }
         Insert: {
@@ -666,6 +679,10 @@ export type Database = {
           expense_date?: string
           id?: string
           notes?: string | null
+          recurring_plan_id?: string | null
+          occurrence_date?: string | null
+          deleted_at?: string | null
+          status?: string
           updated_at?: string
         }
         Update: {
@@ -677,6 +694,58 @@ export type Database = {
           expense_date?: string
           id?: string
           notes?: string | null
+          recurring_plan_id?: string | null
+          occurrence_date?: string | null
+          deleted_at?: string | null
+          status?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      financial_recurrences: {
+        Row: {
+          active: boolean
+          created_at: string
+          end_date: string | null
+          frequency: string
+          id: string
+          interval_count: number
+          last_generated_date: string | null
+          max_occurrences: number | null
+          start_date: string
+          template: Json
+          tenant_id: string
+          tipo: string
+          updated_at: string
+        }
+        Insert: {
+          active?: boolean
+          created_at?: string
+          end_date?: string | null
+          frequency: string
+          id?: string
+          interval_count?: number
+          last_generated_date?: string | null
+          max_occurrences?: number | null
+          start_date: string
+          template?: Json
+          tenant_id: string
+          tipo: string
+          updated_at?: string
+        }
+        Update: {
+          active?: boolean
+          created_at?: string
+          end_date?: string | null
+          frequency?: string
+          id?: string
+          interval_count?: number
+          last_generated_date?: string | null
+          max_occurrences?: number | null
+          start_date?: string
+          template?: Json
+          tenant_id?: string
+          tipo?: string
           updated_at?: string
         }
         Relationships: []

--- a/src/pages/Expenses.tsx
+++ b/src/pages/Expenses.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useEffect, useMemo, useState } from "react";
 import { useAuth } from "@/hooks/useAuth";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -11,11 +12,23 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Badge } from "@/components/ui/badge";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Calendar } from "@/components/ui/calendar";
-import { Calendar as CalendarIcon, Plus, Trash2, TrendingDown } from "lucide-react";
+import { Calendar as CalendarIcon, Plus, Repeat, Trash2, TrendingDown } from "lucide-react";
 import { format } from "date-fns";
 import { ptBR } from "date-fns/locale";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
+import { Switch } from "@/components/ui/switch";
+
+const RECURRENCE_FREQUENCIES = [
+  { value: "daily", label: "Diário" },
+  { value: "weekly", label: "Semanal" },
+  { value: "biweekly", label: "Quinzenal" },
+  { value: "monthly", label: "Mensal" },
+  { value: "bimonthly", label: "Bimestral" },
+  { value: "quarterly", label: "Trimestral" },
+  { value: "semiannual", label: "Semestral" },
+  { value: "annual", label: "Anual" },
+];
 
 const CATEGORIES = [
   "Aluguel",
@@ -37,6 +50,9 @@ interface Expense {
   category: string | null;
   expense_date: string;
   notes: string | null;
+  recurring_plan_id: string | null;
+  status: string;
+  deleted_at: string | null;
 }
 
 export default function Expenses() {
@@ -53,6 +69,12 @@ export default function Expenses() {
   const [notes, setNotes] = useState("");
   const [date, setDate] = useState<Date>(new Date());
   const [submitting, setSubmitting] = useState(false);
+  const [recurring, setRecurring] = useState(false);
+  const [frequency, setFrequency] = useState("monthly");
+  const [endMode, setEndMode] = useState<"never" | "date" | "count">("never");
+  const [endDate, setEndDate] = useState("");
+  const [maxOccurrences, setMaxOccurrences] = useState("");
+  const [recurringFilter, setRecurringFilter] = useState<"all" | "recurring" | "single">("all");
 
   const { data: expenses } = useQuery<Expense[]>({
     queryKey: ["expenses", profile?.id],
@@ -62,11 +84,18 @@ export default function Expenses() {
         .from("expenses")
         .select("*")
         .eq("establishment_id", profile.id)
+        .is("deleted_at", null)
         .order("expense_date", { ascending: false });
       return (data ?? []) as Expense[];
     },
     enabled: !!profile?.id,
   });
+
+  const filteredExpenses = useMemo(() => {
+    if (recurringFilter === "recurring") return (expenses ?? []).filter((e) => e.recurring_plan_id);
+    if (recurringFilter === "single") return (expenses ?? []).filter((e) => !e.recurring_plan_id);
+    return expenses ?? [];
+  }, [expenses, recurringFilter]);
 
   const monthTotal = useMemo(() => {
     if (!expenses) return 0;
@@ -80,8 +109,8 @@ export default function Expenses() {
   }, [expenses]);
 
   const total = useMemo(
-    () => (expenses ?? []).reduce((s, e) => s + Number(e.amount), 0),
-    [expenses]
+    () => (filteredExpenses ?? []).reduce((s, e) => s + Number(e.amount), 0),
+    [filteredExpenses]
   );
 
   const onSubmit = async (e: React.FormEvent) => {
@@ -93,14 +122,29 @@ export default function Expenses() {
     }
     setSubmitting(true);
     try {
-      const { error } = await supabase.from("expenses").insert({
-        establishment_id: profile.id,
+      const payload = {
         description,
         amount: Number(amount),
         category,
-        expense_date: date.toISOString(),
         notes: notes || null,
-      });
+      };
+      const { error } = recurring
+        ? await supabase.rpc("create_financial_recurrence" as never, {
+            p_tenant_id: profile.id,
+            p_tipo: "payable",
+            p_frequency: frequency,
+            p_start_date: format(date, "yyyy-MM-dd"),
+            p_end_date: endMode === "date" && endDate ? endDate : null,
+            p_max_occurrences: endMode === "count" && maxOccurrences ? Number(maxOccurrences) : null,
+            p_template: payload,
+            p_generate_until: endMode === "never" ? format(new Date(date.getFullYear() + 1, date.getMonth(), date.getDate()), "yyyy-MM-dd") : null,
+          } as never)
+        : await supabase.from("expenses").insert({
+            establishment_id: profile.id,
+            ...payload,
+            expense_date: date.toISOString(),
+            status: "confirmed",
+          });
       if (error) throw error;
       toast.success("Despesa registrada!");
       setDescription("");
@@ -108,6 +152,10 @@ export default function Expenses() {
       setCategory("Outros");
       setNotes("");
       setDate(new Date());
+      setRecurring(false);
+      setEndMode("never");
+      setEndDate("");
+      setMaxOccurrences("");
       qc.invalidateQueries({ queryKey: ["expenses", profile.id] });
     } catch (err: any) {
       toast.error(err?.message ?? "Erro ao salvar.");
@@ -116,9 +164,12 @@ export default function Expenses() {
     }
   };
 
-  const onDelete = async (id: string) => {
-    if (!confirm("Excluir esta despesa?")) return;
-    const { error } = await supabase.from("expenses").delete().eq("id", id);
+  const onDelete = async (item: Expense) => {
+    const future = item.recurring_plan_id && confirm("OK: excluir esta e todas as próximas ocorrências. Cancelar: excluir somente esta ocorrência.");
+    const query = future
+      ? supabase.from("expenses").update({ deleted_at: new Date().toISOString() }).eq("recurring_plan_id", item.recurring_plan_id).gte("expense_date", item.expense_date)
+      : supabase.from("expenses").update({ deleted_at: new Date().toISOString() }).eq("id", item.id);
+    const { error } = await query;
     if (error) return toast.error(error.message);
     toast.success("Despesa excluída.");
     qc.invalidateQueries({ queryKey: ["expenses", profile?.id] });
@@ -180,7 +231,7 @@ export default function Expenses() {
                 </Select>
               </div>
               <div className="space-y-2">
-                <Label>Data</Label>
+                <Label>{recurring ? "Data inicial" : "Data"}</Label>
                 <Popover>
                   <PopoverTrigger asChild>
                     <Button type="button" variant="outline" className={cn("justify-start", !date && "text-muted-foreground")}>
@@ -192,6 +243,20 @@ export default function Expenses() {
                     <Calendar mode="single" selected={date} onSelect={(d) => d && setDate(d)} initialFocus className="p-3 pointer-events-auto" />
                   </PopoverContent>
                 </Popover>
+              </div>
+              <div className="md:col-span-2 rounded-md border p-3 space-y-3">
+                <div className="flex items-center justify-between gap-3">
+                  <Label htmlFor="recurring-expense">Lançamento recorrente</Label>
+                  <Switch id="recurring-expense" checked={recurring} onCheckedChange={setRecurring} />
+                </div>
+                {recurring && (
+                  <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                    <div className="space-y-2"><Label>Frequência</Label><Select value={frequency} onValueChange={setFrequency}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent>{RECURRENCE_FREQUENCIES.map((f) => <SelectItem key={f.value} value={f.value}>{f.label}</SelectItem>)}</SelectContent></Select></div>
+                    <div className="space-y-2"><Label>Encerramento</Label><Select value={endMode} onValueChange={(v: any) => setEndMode(v)}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent><SelectItem value="never">Recorrência infinita</SelectItem><SelectItem value="date">Até uma data</SelectItem><SelectItem value="count">Quantidade</SelectItem></SelectContent></Select></div>
+                    {endMode === "date" && <div className="space-y-2"><Label>Data final</Label><Input type="date" value={endDate} onChange={(e) => setEndDate(e.target.value)} /></div>}
+                    {endMode === "count" && <div className="space-y-2"><Label>Gerar ocorrências</Label><Input type="number" min="1" placeholder="12, 24, 60..." value={maxOccurrences} onChange={(e) => setMaxOccurrences(e.target.value)} /></div>}
+                  </div>
+                )}
               </div>
               <div className="space-y-2 md:col-span-2">
                 <Label>Observações</Label>
@@ -208,19 +273,21 @@ export default function Expenses() {
 
         <Card>
           <CardHeader>
-            <CardTitle>Histórico</CardTitle>
+            <CardTitle className="flex items-center justify-between gap-3"><span>Histórico</span><Select value={recurringFilter} onValueChange={(v: any) => setRecurringFilter(v)}><SelectTrigger className="w-[210px]"><SelectValue /></SelectTrigger><SelectContent><SelectItem value="all">Todas</SelectItem><SelectItem value="recurring">Apenas recorrentes</SelectItem><SelectItem value="single">Apenas não recorrentes</SelectItem></SelectContent></Select></CardTitle>
           </CardHeader>
           <CardContent>
-            {!expenses || expenses.length === 0 ? (
+            {filteredExpenses.length === 0 ? (
               <p className="text-sm text-muted-foreground">Nenhuma despesa registrada ainda.</p>
             ) : (
               <div className="space-y-2">
-                {expenses.map((e) => (
+                {filteredExpenses.map((e) => (
                   <div key={e.id} className="flex items-center justify-between gap-3 rounded-md border p-3 hover:bg-muted/40 transition-colors">
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2 flex-wrap">
                         <span className="font-medium truncate">{e.description}</span>
                         {e.category && <Badge variant="secondary">{e.category}</Badge>}
+                        {e.recurring_plan_id && <Badge variant="outline" className="gap-1"><Repeat className="h-3 w-3" /> Recorrente</Badge>}
+                        {e.status === "pending" && <Badge variant="outline">Pendente</Badge>}
                       </div>
                       <div className="text-xs text-muted-foreground mt-0.5">
                         {format(new Date(e.expense_date), "dd 'de' MMM yyyy", { locale: ptBR })}
@@ -230,7 +297,7 @@ export default function Expenses() {
                     <div className="text-right">
                       <div className="font-semibold text-destructive">R$ {Number(e.amount).toFixed(2)}</div>
                     </div>
-                    <Button variant="ghost" size="icon" onClick={() => onDelete(e.id)}>
+                    <Button variant="ghost" size="icon" onClick={() => onDelete(e)}>
                       <Trash2 className="h-4 w-4" />
                     </Button>
                   </div>

--- a/supabase/migrations/20260722090000_add_financial_recurring_entries.sql
+++ b/supabase/migrations/20260722090000_add_financial_recurring_entries.sql
@@ -1,0 +1,179 @@
+-- Recurring financial entries for payables (expenses) and receivables (cash flow)
+CREATE TABLE IF NOT EXISTS public.financial_recurrences (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  tipo TEXT NOT NULL CHECK (tipo IN ('payable','receivable')),
+  frequency TEXT NOT NULL CHECK (frequency IN ('daily','weekly','biweekly','monthly','bimonthly','quarterly','semiannual','annual')),
+  interval_count INTEGER NOT NULL DEFAULT 1 CHECK (interval_count > 0),
+  start_date DATE NOT NULL,
+  end_date DATE,
+  max_occurrences INTEGER CHECK (max_occurrences IS NULL OR max_occurrences > 0),
+  active BOOLEAN NOT NULL DEFAULT true,
+  last_generated_date DATE,
+  template JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CHECK (end_date IS NULL OR end_date >= start_date)
+);
+
+ALTER TABLE public.financial_recurrences ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Establishments can manage their financial recurrences"
+ON public.financial_recurrences
+FOR ALL
+USING (tenant_id IN (SELECT profiles.id FROM public.profiles WHERE profiles.user_id = auth.uid()))
+WITH CHECK (tenant_id IN (SELECT profiles.id FROM public.profiles WHERE profiles.user_id = auth.uid()));
+
+CREATE POLICY "Super admins can view all financial recurrences"
+ON public.financial_recurrences
+FOR SELECT
+USING (has_role(auth.uid(), 'super_admin'::app_role));
+
+CREATE TRIGGER update_financial_recurrences_updated_at
+BEFORE UPDATE ON public.financial_recurrences
+FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+ALTER TABLE public.expenses
+  ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'confirmed' CHECK (status IN ('confirmed','pending','paid')),
+  ADD COLUMN IF NOT EXISTS recurring_plan_id UUID REFERENCES public.financial_recurrences(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS occurrence_date DATE,
+  ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+
+ALTER TABLE public.cash_flow_entries
+  ADD COLUMN IF NOT EXISTS recurring_plan_id UUID REFERENCES public.financial_recurrences(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS occurrence_date DATE,
+  ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+
+ALTER TABLE public.cash_flow_entries DROP CONSTRAINT IF EXISTS cash_flow_entries_source_check;
+ALTER TABLE public.cash_flow_entries ADD CONSTRAINT cash_flow_entries_source_check CHECK (source IN ('sale','expense','manual','recurrence'));
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_expenses_recurring_occurrence
+  ON public.expenses(recurring_plan_id, occurrence_date) WHERE recurring_plan_id IS NOT NULL AND deleted_at IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_cfe_recurring_occurrence
+  ON public.cash_flow_entries(recurring_plan_id, occurrence_date) WHERE recurring_plan_id IS NOT NULL AND deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_financial_recurrences_due
+  ON public.financial_recurrences(active, tenant_id, last_generated_date, start_date);
+CREATE INDEX IF NOT EXISTS idx_expenses_recurring_filter
+  ON public.expenses(establishment_id, recurring_plan_id, expense_date DESC) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_cfe_recurring_filter
+  ON public.cash_flow_entries(establishment_id, recurring_plan_id, entry_date DESC) WHERE deleted_at IS NULL;
+
+CREATE OR REPLACE FUNCTION public.financial_recurrence_step(freq TEXT, mult INTEGER DEFAULT 1)
+RETURNS INTERVAL LANGUAGE sql IMMUTABLE AS $$
+  SELECT CASE freq
+    WHEN 'daily' THEN make_interval(days => 1 * mult)
+    WHEN 'weekly' THEN make_interval(days => 7 * mult)
+    WHEN 'biweekly' THEN make_interval(days => 14 * mult)
+    WHEN 'monthly' THEN make_interval(months => 1 * mult)
+    WHEN 'bimonthly' THEN make_interval(months => 2 * mult)
+    WHEN 'quarterly' THEN make_interval(months => 3 * mult)
+    WHEN 'semiannual' THEN make_interval(months => 6 * mult)
+    WHEN 'annual' THEN make_interval(years => 1 * mult)
+    ELSE make_interval(months => 1 * mult)
+  END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.create_financial_recurrence(
+  p_tenant_id UUID,
+  p_tipo TEXT,
+  p_frequency TEXT,
+  p_start_date DATE,
+  p_end_date DATE DEFAULT NULL,
+  p_max_occurrences INTEGER DEFAULT NULL,
+  p_template JSONB DEFAULT '{}'::jsonb,
+  p_generate_until DATE DEFAULT (CURRENT_DATE + INTERVAL '12 months')::date
+) RETURNS UUID
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE v_id UUID;
+BEGIN
+  IF p_end_date IS NOT NULL AND p_max_occurrences IS NOT NULL THEN
+    RAISE EXCEPTION 'Informe data final ou quantidade de ocorrências, não ambos';
+  END IF;
+
+  INSERT INTO public.financial_recurrences(tenant_id, tipo, frequency, start_date, end_date, max_occurrences, template)
+  VALUES (p_tenant_id, p_tipo, p_frequency, p_start_date, p_end_date, p_max_occurrences, p_template)
+  RETURNING id INTO v_id;
+
+  PERFORM public.generate_financial_recurrence(v_id, p_generate_until);
+  RETURN v_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.generate_financial_recurrence(p_recurrence_id UUID, p_until DATE DEFAULT CURRENT_DATE)
+RETURNS INTEGER
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE r public.financial_recurrences%ROWTYPE; occ DATE; generated INTEGER := 0; idx INTEGER := 0; stop_date DATE;
+BEGIN
+  SELECT * INTO r FROM public.financial_recurrences WHERE id = p_recurrence_id AND active = true FOR UPDATE;
+  IF NOT FOUND THEN RETURN 0; END IF;
+
+  stop_date := LEAST(COALESCE(r.end_date, p_until), p_until);
+  occ := r.start_date;
+  WHILE occ <= stop_date LOOP
+    idx := idx + 1;
+    IF r.max_occurrences IS NOT NULL AND idx > r.max_occurrences THEN EXIT; END IF;
+
+    IF r.tipo = 'payable' THEN
+      INSERT INTO public.expenses(establishment_id, description, amount, category, expense_date, notes, status, recurring_plan_id, occurrence_date)
+      VALUES (r.tenant_id, r.template->>'description', (r.template->>'amount')::numeric, r.template->>'category', occ::timestamptz, r.template->>'notes', 'pending', r.id, occ)
+      ON CONFLICT (recurring_plan_id, occurrence_date) WHERE recurring_plan_id IS NOT NULL AND deleted_at IS NULL DO NOTHING;
+    ELSE
+      INSERT INTO public.cash_flow_entries(establishment_id, entry_type, category, description, amount, payment_method, status, entry_date, source, notes, recurring_plan_id, occurrence_date)
+      VALUES (r.tenant_id, 'income', COALESCE(r.template->>'category','Receita recorrente'), r.template->>'description', (r.template->>'amount')::numeric, r.template->>'payment_method', 'pending', occ::timestamptz, 'recurrence', r.template->>'notes', r.id, occ)
+      ON CONFLICT (recurring_plan_id, occurrence_date) WHERE recurring_plan_id IS NOT NULL AND deleted_at IS NULL DO NOTHING;
+    END IF;
+    generated := generated + 1;
+    occ := (occ::timestamp + public.financial_recurrence_step(r.frequency, r.interval_count))::date;
+  END LOOP;
+
+  UPDATE public.financial_recurrences SET last_generated_date = stop_date, active = CASE WHEN r.end_date IS NOT NULL AND stop_date >= r.end_date THEN false ELSE active END WHERE id = r.id;
+  RETURN generated;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.generate_due_financial_recurrences(p_until DATE DEFAULT CURRENT_DATE)
+RETURNS INTEGER
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE rec RECORD; total INTEGER := 0;
+BEGIN
+  FOR rec IN SELECT id FROM public.financial_recurrences WHERE active = true AND start_date <= p_until LOOP
+    total := total + public.generate_financial_recurrence(rec.id, p_until);
+  END LOOP;
+  RETURN total;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.sync_expense_to_cash_flow()
+RETURNS TRIGGER
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    DELETE FROM public.cash_flow_entries WHERE source = 'expense' AND source_id = OLD.id;
+    RETURN OLD;
+  END IF;
+
+  IF TG_OP = 'INSERT' THEN
+    INSERT INTO public.cash_flow_entries (establishment_id, entry_type, category, description, amount, payment_method, status, entry_date, source, source_id, notes, recurring_plan_id, occurrence_date)
+    VALUES (NEW.establishment_id, 'expense', COALESCE(NEW.category, 'Despesa'), NEW.description, NEW.amount,
+      CASE WHEN NEW.notes ~* 'pix|dinheiro|cart[ãa]o|d[eé]bito|cr[eé]dito|boleto|transfer' THEN NEW.notes ELSE NULL END,
+      CASE WHEN NEW.status = 'pending' THEN 'pending' ELSE 'confirmed' END, NEW.expense_date, 'expense', NEW.id, NEW.notes, NEW.recurring_plan_id, NEW.occurrence_date);
+  ELSIF TG_OP = 'UPDATE' THEN
+    UPDATE public.cash_flow_entries SET establishment_id = NEW.establishment_id, category = COALESCE(NEW.category, 'Despesa'), description = NEW.description,
+      amount = NEW.amount, status = CASE WHEN NEW.status = 'pending' THEN 'pending' ELSE 'confirmed' END, entry_date = NEW.expense_date,
+      notes = NEW.notes, recurring_plan_id = NEW.recurring_plan_id, occurrence_date = NEW.occurrence_date, updated_at = now()
+    WHERE source = 'expense' AND source_id = NEW.id;
+  END IF;
+  RETURN NEW;
+END; $$;
+
+-- Daily automatic generation. If pg_cron is unavailable in an environment,
+-- the function above can still be invoked by an external scheduler.
+CREATE EXTENSION IF NOT EXISTS pg_cron WITH SCHEMA extensions;
+SELECT cron.schedule(
+  'generate-due-financial-recurrences-daily',
+  '5 3 * * *',
+  $$SELECT public.generate_due_financial_recurrences(CURRENT_DATE);$$
+)
+WHERE NOT EXISTS (
+  SELECT 1 FROM cron.job WHERE jobname = 'generate-due-financial-recurrences-daily'
+);


### PR DESCRIPTION
### Motivation
- Permitir que despesas e recebimentos fixos sejam gerados automaticamente para evitar lançamentos manuais repetidos. 
- Oferecer uma solução escalável que mantenha cada ocorrência independente e respeite isolamento por tenant.

### Description
- Banco: adicionada a tabela `financial_recurrences` e colunas em `expenses` e `cash_flow_entries` (`recurring_plan_id`, `occurrence_date`, `deleted_at`, `status`) com índices únicos para evitar duplicados e políticas RLS; incluída rotina de agendamento diário via `pg_cron` para geração automática. 
- Lógica: implementadas funções SQL `create_financial_recurrence`, `generate_financial_recurrence`, `generate_due_financial_recurrences` e `financial_recurrence_step` e ajustado o trigger de sincronização `sync_expense_to_cash_flow` para preservar status, recorrência e ocorrência. 
- UI/UX: na página de `Despesas` foi adicionado o switch `Lançamento recorrente`, seleção de `Frequência`, opções de encerramento (`infinito / até data / quantidade`), criação via RPC (`create_financial_recurrence`), filtro de lista (`Todas / Apenas recorrentes / Apenas não recorrentes`) e indicador visual `🔁 Recorrente`; no `Fluxo de caixa` o modal de novo lançamento ganhou controle de recorrência e a listagem recebeu filtro e indicador de recorrência. 
- Tipos: atualizados os tipos Supabase em `src/integrations/supabase/types.ts` para refletir os novos campos e a nova entidade `financial_recurrences`.

### Testing
- `npm run build` — build da aplicação concluído com sucesso. 
- `npx eslint src/pages/Expenses.tsx src/components/reports/CashFlowReport.tsx` — lint restrito aos arquivos alterados executado e ajustado (forçando `@typescript-eslint/no-explicit-any` onde necessário) para a PR. 
- `npm run lint` — executou e falhou devido a erros de lint preexistentes em arquivos fora do escopo desta mudança, sem relação direta com as alterações aqui introduzidas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61503f58488327af6abcb50485e11b)