### PR TITLE
Accounts payable: refactor Expenses UI and add DB migrations for payables lifecycle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ import Clients from "./pages/Clients";
 import Services from "./pages/Services";
 import Products from "./pages/Products";
 import Sales from "./pages/Sales";
-import Expenses from "./pages/Expenses";
+import Expenses from "./pages/AccountsPayable";
 import Agenda from "./pages/StableAgenda";
 import Reports from "./pages/Reports";
 import Metrics from "./pages/Metrics";

--- a/src/pages/AccountsPayable.tsx
+++ b/src/pages/AccountsPayable.tsx
@@ -1,0 +1,121 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { useEffect, useMemo, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { format, isSameMonth } from "date-fns";
+import { ptBR } from "date-fns/locale";
+import { AlertTriangle, CalendarClock, CheckCircle2, Pencil, Plus, Search, Trash2, WalletCards } from "lucide-react";
+import { toast } from "sonner";
+import { useAuth } from "@/hooks/useAuth";
+import { supabase } from "@/integrations/supabase/client";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+
+const CATEGORIES = ["Aluguel", "Água", "Energia", "Internet", "Marketing", "Produtos", "Funcionários", "Impostos", "Equipamentos", "Manutenção", "Outros"];
+const CENTERS = ["Administrativo", "Recepção", "Marketing", "Estoque", "Serviços", "Produtos"];
+const STATUS: Record<string, [string, "default" | "secondary" | "destructive" | "outline"]> = {
+  pending: ["Pendente", "secondary"], due_today: ["Vence hoje", "default"], overdue: ["Vencida", "destructive"],
+  partially_paid: ["Parcialmente paga", "outline"], paid: ["Paga", "secondary"], confirmed: ["Paga", "secondary"], cancelled: ["Cancelada", "outline"],
+};
+const money = (value: number) => value.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
+const isMissingPayablesSchema = (error: any) => error?.code === "PGRST202" || /schema cache|create_payables/i.test(error?.message ?? "");
+
+interface Expense {
+  id: string; description: string; amount: number; paid_amount: number; category: string | null; supplier: string | null;
+  cost_center: string | null; notes: string | null; due_date: string; competence_date: string | null; expense_date: string;
+  status: string; installment_number: number | null; installment_count: number | null; recurring_plan_id: string | null;
+}
+interface FormState { description: string; amount: string; category: string; supplier: string; cost_center: string; notes: string; due_date: string; competence_date: string; installments: string }
+const initialForm = (): FormState => ({ description: "", amount: "", category: "Outros", supplier: "", cost_center: "Administrativo", notes: "", due_date: format(new Date(), "yyyy-MM-dd"), competence_date: format(new Date(), "yyyy-MM-dd"), installments: "1" });
+
+// Kept at module scope: defining this component inside Expenses remounted every input on each render and caused focus loss.
+function FormField({ label, field, type = "text", form, onChange }: { label: string; field: keyof FormState; type?: string; form: FormState; onChange: (field: keyof FormState, value: string) => void }) {
+  return <div className="space-y-1"><Label htmlFor={`expense-${field}`}>{label}</Label><Input id={`expense-${field}`} type={type} step={type === "number" ? "0.01" : undefined} value={form[field]} onChange={(event) => onChange(field, event.target.value)} /></div>;
+}
+function Metric({ title, value, icon: Icon }: any) { return <Card><CardContent className="pt-5 flex justify-between"><div><p className="text-xs text-muted-foreground">{title}</p><p className="text-xl font-bold mt-1">{value}</p></div><Icon className="h-5 w-5 text-primary" /></CardContent></Card>; }
+function PayField({ label, field, payment, setPayment, type = "text" }: any) { return <div className="space-y-1"><Label htmlFor={`payment-${field}`}>{label}</Label><Input id={`payment-${field}`} type={type} step={type === "number" ? "0.01" : undefined} value={payment[field]} onChange={(event) => setPayment((current: any) => ({ ...current, [field]: event.target.value }))} /></div>; }
+
+function normalizeExpense(row: any): Expense {
+  const date = (row.due_date || row.expense_date || "").slice(0, 10);
+  const legacyPaid = row.status === "confirmed" || row.status === "paid";
+  return { ...row, due_date: date, competence_date: row.competence_date || date, paid_amount: Number(row.paid_amount ?? (legacyPaid ? row.amount : 0)), supplier: row.supplier ?? null, cost_center: row.cost_center ?? null, installment_number: row.installment_number ?? null, installment_count: row.installment_count ?? null, recurring_plan_id: row.recurring_plan_id ?? null };
+}
+
+export default function Expenses() {
+  const { profile, establishmentRole } = useAuth();
+  const queryClient = useQueryClient();
+  const canManage = establishmentRole === "owner" || establishmentRole === "admin";
+  const isOwner = establishmentRole === "owner";
+  const [form, setForm] = useState<FormState>(initialForm);
+  const [editing, setEditing] = useState<Expense | null>(null);
+  const [paying, setPaying] = useState<Expense | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [payment, setPayment] = useState({ date: format(new Date(), "yyyy-MM-dd"), amount: "", method: "pix", account: "Caixa principal", interest: "0", fine: "0", discount: "0", notes: "" });
+  const [filters, setFilters] = useState({ q: "", status: "all", category: "all", supplier: "", from: "", to: "", min: "", max: "" });
+
+  useEffect(() => { document.title = "Contas a Pagar | Beauty Core"; }, []);
+  const { data: expenses = [], isLoading, error: listError } = useQuery<Expense[]>({
+    queryKey: ["payables", profile?.id], enabled: !!profile?.id,
+    queryFn: async () => {
+      // Do not order/filter by new columns on the server: production can briefly run the old schema while migrations propagate.
+      const { data, error } = await supabase.from("expenses").select("*").eq("establishment_id", profile.id).order("expense_date", { ascending: false });
+      if (error) throw error;
+      return (data ?? []).filter((row: any) => !row.deleted_at).map(normalizeExpense).sort((a, b) => b.due_date.localeCompare(a.due_date));
+    },
+  });
+  useEffect(() => { if (listError) toast.error(`Não foi possível carregar as despesas: ${(listError as Error).message}`); }, [listError]);
+
+  const rows = useMemo(() => expenses.filter((expense) => {
+    const q = filters.q.toLowerCase();
+    return (!q || expense.description.toLowerCase().includes(q) || (expense.supplier || "").toLowerCase().includes(q))
+      && (filters.status === "all" || expense.status === filters.status || (filters.status === "paid" && expense.status === "confirmed"))
+      && (filters.category === "all" || expense.category === filters.category)
+      && (!filters.supplier || (expense.supplier || "").toLowerCase().includes(filters.supplier.toLowerCase()))
+      && (!filters.from || expense.due_date >= filters.from) && (!filters.to || expense.due_date <= filters.to)
+      && (!filters.min || expense.amount >= Number(filters.min)) && (!filters.max || expense.amount <= Number(filters.max));
+  }), [expenses, filters]);
+  const totals = useMemo(() => ({
+    open: expenses.filter((expense) => !["paid", "confirmed", "cancelled"].includes(expense.status)).reduce((sum, expense) => sum + expense.amount - expense.paid_amount, 0),
+    paid: expenses.filter((expense) => ["paid", "confirmed"].includes(expense.status) && isSameMonth(new Date(`${expense.due_date}T12:00:00`), new Date())).reduce((sum, expense) => sum + expense.paid_amount, 0),
+    overdue: expenses.filter((expense) => expense.status === "overdue").reduce((sum, expense) => sum + expense.amount - expense.paid_amount, 0),
+    today: expenses.filter((expense) => expense.status === "due_today").length,
+  }), [expenses]);
+  const invalidate = () => { queryClient.invalidateQueries({ queryKey: ["payables", profile?.id] }); queryClient.invalidateQueries({ queryKey: ["reports"] }); queryClient.invalidateQueries({ queryKey: ["cash-flow"] }); };
+  const changeForm = (field: keyof FormState, value: string) => setForm((current) => ({ ...current, [field]: value }));
+
+  const legacyCreate = async () => {
+    const count = Math.max(1, Number(form.installments)); const total = Number(form.amount); const parcel = Math.round((total / count) * 100) / 100;
+    const records = Array.from({ length: count }, (_, index) => { const due = new Date(`${form.due_date}T12:00:00`); due.setMonth(due.getMonth() + index); return { establishment_id: profile.id, description: count > 1 ? `${form.description} (${index + 1}/${count})` : form.description, amount: index === count - 1 ? total - parcel * (count - 1) : parcel, category: form.category, notes: form.notes || null, expense_date: due.toISOString(), status: "pending" }; });
+    const { error } = await supabase.from("expenses").insert(records); if (error) throw error;
+    toast.warning("Conta salva no modo de compatibilidade. Os dados complementares serão habilitados após a migração do banco.");
+  };
+  const save = async (event: React.FormEvent) => {
+    event.preventDefault(); if (!canManage || !form.description.trim() || Number(form.amount) <= 0) return toast.error("Informe descrição e valor válido.");
+    setBusy(true);
+    try {
+      const data = { ...form, amount: Number(form.amount) };
+      let result = editing ? await (supabase as any).rpc("update_payable", { p_id: editing.id, p_changes: data }) : await (supabase as any).rpc("create_payables", { p_establishment: profile.id, p_data: data, p_installments: Number(form.installments) });
+      if (result.error && isMissingPayablesSchema(result.error)) {
+        if (editing) result = await supabase.from("expenses").update({ description: form.description, amount: Number(form.amount), category: form.category, notes: form.notes || null, expense_date: new Date(`${form.due_date}T12:00:00`).toISOString() }).eq("id", editing.id);
+        else { await legacyCreate(); result = { error: null }; }
+      }
+      if (result.error) throw result.error;
+      toast.success(editing ? "Despesa atualizada." : "Conta a pagar criada."); setEditing(null); setForm(initialForm()); invalidate();
+    } catch (error: any) { toast.error(error.message); } finally { setBusy(false); }
+  };
+  const openEdit = (expense: Expense) => { setEditing(expense); setForm({ description: expense.description, amount: String(expense.amount), category: expense.category || "Outros", supplier: expense.supplier || "", cost_center: expense.cost_center || "Administrativo", notes: expense.notes || "", due_date: expense.due_date, competence_date: expense.competence_date || expense.due_date, installments: String(expense.installment_count || 1) }); };
+  const pay = async () => { if (!paying) return; setBusy(true); try { const { error } = await (supabase as any).rpc("pay_expense", { p_id: paying.id, p_payment_date: payment.date, p_amount: Number(payment.amount), p_method: payment.method, p_account: payment.account, p_interest: Number(payment.interest), p_fine: Number(payment.fine), p_discount: Number(payment.discount), p_notes: payment.notes || null }); if (error) throw error; toast.success("Pagamento registrado e fluxo de caixa atualizado."); setPaying(null); invalidate(); } catch (error: any) { toast.error(error.message); } finally { setBusy(false); } };
+  const remove = async (expense: Expense) => { if (!isOwner || !confirm(`Excluir “${expense.description}”? Movimentações relacionadas também serão removidas.`)) return; const { error } = await (supabase as any).rpc("delete_payable", { p_id: expense.id }); if (error) toast.error(error.message); else { toast.success("Despesa excluída."); invalidate(); } };
+
+  return <div className="min-h-screen bg-background"><header className="border-b bg-card"><div className="container mx-auto px-4 py-6"><h1 className="text-2xl font-bold">Contas a Pagar</h1><p className="text-muted-foreground">Do previsto à quitação, com integração automática ao fluxo de caixa</p></div></header><main className="container mx-auto px-4 py-6 space-y-5">
+    <div className="grid gap-3 grid-cols-2 lg:grid-cols-4"><Metric title="Total em aberto" value={money(totals.open)} icon={WalletCards} /><Metric title="Pago no mês" value={money(totals.paid)} icon={CheckCircle2} /><Metric title="Total vencido" value={money(totals.overdue)} icon={AlertTriangle} /><Metric title="Vencem hoje" value={String(totals.today)} icon={CalendarClock} /></div>
+    {canManage && <Card><CardHeader><CardTitle className="flex gap-2"><Plus className="h-5 w-5" />{editing ? "Editar despesa" : "Nova conta a pagar"}</CardTitle></CardHeader><CardContent><form onSubmit={save} className="grid md:grid-cols-4 gap-3"><div className="md:col-span-2"><FormField label="Descrição" field="description" form={form} onChange={changeForm} /></div><FormField label="Fornecedor" field="supplier" form={form} onChange={changeForm} /><FormField label="Valor total" field="amount" type="number" form={form} onChange={changeForm} /><div className="space-y-1"><Label>Categoria</Label><Select value={form.category} onValueChange={(value) => changeForm("category", value)}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent>{CATEGORIES.map((item) => <SelectItem key={item} value={item}>{item}</SelectItem>)}</SelectContent></Select></div><div className="space-y-1"><Label>Centro de custo</Label><Select value={form.cost_center} onValueChange={(value) => changeForm("cost_center", value)}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent>{CENTERS.map((item) => <SelectItem key={item} value={item}>{item}</SelectItem>)}</SelectContent></Select></div><FormField label="Competência" field="competence_date" type="date" form={form} onChange={changeForm} /><FormField label="Vencimento" field="due_date" type="date" form={form} onChange={changeForm} />{!editing && <FormField label="Parcelas" field="installments" type="number" form={form} onChange={changeForm} />}<div className="md:col-span-3 space-y-1"><Label>Observações</Label><Textarea value={form.notes} onChange={(event) => changeForm("notes", event.target.value)} /></div><div className="md:col-span-4 flex gap-2"><Button disabled={busy}>{busy ? "Salvando..." : "Salvar"}</Button>{editing && <Button type="button" variant="outline" onClick={() => { setEditing(null); setForm(initialForm()); }}>Cancelar</Button>}</div></form></CardContent></Card>}
+    <Card><CardHeader><CardTitle>Contas</CardTitle></CardHeader><CardContent className="space-y-4"><div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-2"><div className="relative"><Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" /><Input className="pl-9" placeholder="Descrição ou fornecedor" value={filters.q} onChange={(event) => setFilters({ ...filters, q: event.target.value })} /></div><Select value={filters.status} onValueChange={(status) => setFilters({ ...filters, status })}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent><SelectItem value="all">Todos os status</SelectItem>{Object.entries(STATUS).filter(([key]) => key !== "confirmed").map(([key, value]) => <SelectItem value={key} key={key}>{value[0]}</SelectItem>)}</SelectContent></Select><Select value={filters.category} onValueChange={(category) => setFilters({ ...filters, category })}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent><SelectItem value="all">Todas as categorias</SelectItem>{CATEGORIES.map((item) => <SelectItem key={item} value={item}>{item}</SelectItem>)}</SelectContent></Select><Input placeholder="Filtrar fornecedor" value={filters.supplier} onChange={(event) => setFilters({ ...filters, supplier: event.target.value })} /><Input type="date" value={filters.from} onChange={(event) => setFilters({ ...filters, from: event.target.value })} /><Input type="date" value={filters.to} onChange={(event) => setFilters({ ...filters, to: event.target.value })} /><Input type="number" placeholder="Valor mínimo" value={filters.min} onChange={(event) => setFilters({ ...filters, min: event.target.value })} /><Input type="number" placeholder="Valor máximo" value={filters.max} onChange={(event) => setFilters({ ...filters, max: event.target.value })} /></div>
+      {isLoading ? <p>Carregando...</p> : rows.length === 0 ? <p className="text-sm text-muted-foreground py-6 text-center">Nenhuma conta encontrada.</p> : <div className="space-y-2">{rows.map((expense) => { const status = STATUS[expense.status] || STATUS.pending; const balance = expense.amount - expense.paid_amount; return <div key={expense.id} className="rounded-lg border p-3 flex flex-col md:flex-row md:items-center gap-3"><div className="flex-1 min-w-0"><div className="flex flex-wrap gap-2 items-center"><b>{expense.description}</b><Badge variant={status[1]}>{status[0]}</Badge>{expense.installment_count && expense.installment_count > 1 && <Badge variant="outline">{expense.installment_number}/{expense.installment_count}</Badge>}</div><p className="text-xs text-muted-foreground mt-1">Vence {format(new Date(`${expense.due_date}T12:00:00`), "dd 'de' MMMM", { locale: ptBR })} · {expense.supplier || "Sem fornecedor"} · {expense.category || "Sem categoria"} · {expense.cost_center || "Sem centro"}</p>{expense.paid_amount > 0 && <p className="text-xs mt-1">Pago {money(expense.paid_amount)} · Saldo {money(balance)}</p>}</div><div className="font-bold text-destructive">{money(expense.amount)}</div>{canManage && <div className="flex gap-1">{!["paid", "confirmed", "cancelled"].includes(expense.status) && <Button size="sm" onClick={() => { setPaying(expense); setPayment((current) => ({ ...current, amount: String(balance) })); }}>Pagar</Button>}{(!["paid", "confirmed"].includes(expense.status) || isOwner) && <Button size="icon" variant="ghost" onClick={() => openEdit(expense)}><Pencil className="h-4 w-4" /></Button>}{isOwner && <Button size="icon" variant="ghost" onClick={() => remove(expense)}><Trash2 className="h-4 w-4" /></Button>}</div>}</div>; })}</div>}</CardContent></Card>
+  </main><Dialog open={!!paying} onOpenChange={(open) => !open && setPaying(null)}><DialogContent><DialogHeader><DialogTitle>Registrar pagamento</DialogTitle></DialogHeader><div className="grid grid-cols-2 gap-3"><PayField label="Data" field="date" type="date" payment={payment} setPayment={setPayment} /><PayField label="Valor da dívida" field="amount" type="number" payment={payment} setPayment={setPayment} /><PayField label="Juros" field="interest" type="number" payment={payment} setPayment={setPayment} /><PayField label="Multa" field="fine" type="number" payment={payment} setPayment={setPayment} /><PayField label="Desconto" field="discount" type="number" payment={payment} setPayment={setPayment} /><div className="space-y-1"><Label>Forma de pagamento</Label><Select value={payment.method} onValueChange={(method) => setPayment({ ...payment, method })}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent>{["pix", "dinheiro", "boleto", "transferência", "cartão"].map((item) => <SelectItem key={item} value={item}>{item}</SelectItem>)}</SelectContent></Select></div><div className="col-span-2"><PayField label="Conta financeira" field="account" payment={payment} setPayment={setPayment} /></div><div className="col-span-2"><PayField label="Observações" field="notes" payment={payment} setPayment={setPayment} /></div><p className="col-span-2 text-sm font-medium">Saída realizada: {money(Number(payment.amount) + Number(payment.interest) + Number(payment.fine) - Number(payment.discount))}</p></div><DialogFooter><Button variant="outline" onClick={() => setPaying(null)}>Cancelar</Button><Button disabled={busy} onClick={pay}>Confirmar pagamento</Button></DialogFooter></DialogContent></Dialog></div>;
+}

--- a/src/pages/Expenses.tsx
+++ b/src/pages/Expenses.tsx
@@ -1,312 +1,121 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useEffect, useMemo, useState } from "react";
-import { useAuth } from "@/hooks/useAuth";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { format, isSameMonth } from "date-fns";
+import { ptBR } from "date-fns/locale";
+import { AlertTriangle, CalendarClock, CheckCircle2, Pencil, Plus, Search, Trash2, WalletCards } from "lucide-react";
+import { toast } from "sonner";
+import { useAuth } from "@/hooks/useAuth";
 import { supabase } from "@/integrations/supabase/client";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Badge } from "@/components/ui/badge";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { Calendar } from "@/components/ui/calendar";
-import { Calendar as CalendarIcon, Plus, Repeat, Trash2, TrendingDown } from "lucide-react";
-import { format } from "date-fns";
-import { ptBR } from "date-fns/locale";
-import { cn } from "@/lib/utils";
-import { toast } from "sonner";
-import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
 
-const RECURRENCE_FREQUENCIES = [
-  { value: "daily", label: "Diário" },
-  { value: "weekly", label: "Semanal" },
-  { value: "biweekly", label: "Quinzenal" },
-  { value: "monthly", label: "Mensal" },
-  { value: "bimonthly", label: "Bimestral" },
-  { value: "quarterly", label: "Trimestral" },
-  { value: "semiannual", label: "Semestral" },
-  { value: "annual", label: "Anual" },
-];
-
-const CATEGORIES = [
-  "Aluguel",
-  "Energia",
-  "Água",
-  "Internet",
-  "Produtos",
-  "Salários",
-  "Marketing",
-  "Manutenção",
-  "Impostos",
-  "Outros",
-];
+const CATEGORIES = ["Aluguel", "Água", "Energia", "Internet", "Marketing", "Produtos", "Funcionários", "Impostos", "Equipamentos", "Manutenção", "Outros"];
+const CENTERS = ["Administrativo", "Recepção", "Marketing", "Estoque", "Serviços", "Produtos"];
+const STATUS: Record<string, [string, "default" | "secondary" | "destructive" | "outline"]> = {
+  pending: ["Pendente", "secondary"], due_today: ["Vence hoje", "default"], overdue: ["Vencida", "destructive"],
+  partially_paid: ["Parcialmente paga", "outline"], paid: ["Paga", "secondary"], confirmed: ["Paga", "secondary"], cancelled: ["Cancelada", "outline"],
+};
+const money = (value: number) => value.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
+const isMissingPayablesSchema = (error: any) => error?.code === "PGRST202" || /schema cache|create_payables/i.test(error?.message ?? "");
 
 interface Expense {
-  id: string;
-  description: string;
-  amount: number;
-  category: string | null;
-  expense_date: string;
-  notes: string | null;
-  recurring_plan_id: string | null;
-  status: string;
-  deleted_at: string | null;
+  id: string; description: string; amount: number; paid_amount: number; category: string | null; supplier: string | null;
+  cost_center: string | null; notes: string | null; due_date: string; competence_date: string | null; expense_date: string;
+  status: string; installment_number: number | null; installment_count: number | null; recurring_plan_id: string | null;
+}
+interface FormState { description: string; amount: string; category: string; supplier: string; cost_center: string; notes: string; due_date: string; competence_date: string; installments: string }
+const initialForm = (): FormState => ({ description: "", amount: "", category: "Outros", supplier: "", cost_center: "Administrativo", notes: "", due_date: format(new Date(), "yyyy-MM-dd"), competence_date: format(new Date(), "yyyy-MM-dd"), installments: "1" });
+
+// Kept at module scope: defining this component inside Expenses remounted every input on each render and caused focus loss.
+function FormField({ label, field, type = "text", form, onChange }: { label: string; field: keyof FormState; type?: string; form: FormState; onChange: (field: keyof FormState, value: string) => void }) {
+  return <div className="space-y-1"><Label htmlFor={`expense-${field}`}>{label}</Label><Input id={`expense-${field}`} type={type} step={type === "number" ? "0.01" : undefined} value={form[field]} onChange={(event) => onChange(field, event.target.value)} /></div>;
+}
+function Metric({ title, value, icon: Icon }: any) { return <Card><CardContent className="pt-5 flex justify-between"><div><p className="text-xs text-muted-foreground">{title}</p><p className="text-xl font-bold mt-1">{value}</p></div><Icon className="h-5 w-5 text-primary" /></CardContent></Card>; }
+function PayField({ label, field, payment, setPayment, type = "text" }: any) { return <div className="space-y-1"><Label htmlFor={`payment-${field}`}>{label}</Label><Input id={`payment-${field}`} type={type} step={type === "number" ? "0.01" : undefined} value={payment[field]} onChange={(event) => setPayment((current: any) => ({ ...current, [field]: event.target.value }))} /></div>; }
+
+function normalizeExpense(row: any): Expense {
+  const date = (row.due_date || row.expense_date || "").slice(0, 10);
+  const legacyPaid = row.status === "confirmed" || row.status === "paid";
+  return { ...row, due_date: date, competence_date: row.competence_date || date, paid_amount: Number(row.paid_amount ?? (legacyPaid ? row.amount : 0)), supplier: row.supplier ?? null, cost_center: row.cost_center ?? null, installment_number: row.installment_number ?? null, installment_count: row.installment_count ?? null, recurring_plan_id: row.recurring_plan_id ?? null };
 }
 
 export default function Expenses() {
-  const { profile } = useAuth();
-  const qc = useQueryClient();
+  const { profile, establishmentRole } = useAuth();
+  const queryClient = useQueryClient();
+  const canManage = establishmentRole === "owner" || establishmentRole === "admin";
+  const isOwner = establishmentRole === "owner";
+  const [form, setForm] = useState<FormState>(initialForm);
+  const [editing, setEditing] = useState<Expense | null>(null);
+  const [paying, setPaying] = useState<Expense | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [payment, setPayment] = useState({ date: format(new Date(), "yyyy-MM-dd"), amount: "", method: "pix", account: "Caixa principal", interest: "0", fine: "0", discount: "0", notes: "" });
+  const [filters, setFilters] = useState({ q: "", status: "all", category: "all", supplier: "", from: "", to: "", min: "", max: "" });
 
-  useEffect(() => {
-    document.title = "Despesas | Beauty Core";
-  }, []);
-
-  const [description, setDescription] = useState("");
-  const [amount, setAmount] = useState("");
-  const [category, setCategory] = useState("Outros");
-  const [notes, setNotes] = useState("");
-  const [date, setDate] = useState<Date>(new Date());
-  const [submitting, setSubmitting] = useState(false);
-  const [recurring, setRecurring] = useState(false);
-  const [frequency, setFrequency] = useState("monthly");
-  const [endMode, setEndMode] = useState<"never" | "date" | "count">("never");
-  const [endDate, setEndDate] = useState("");
-  const [maxOccurrences, setMaxOccurrences] = useState("");
-  const [recurringFilter, setRecurringFilter] = useState<"all" | "recurring" | "single">("all");
-
-  const { data: expenses } = useQuery<Expense[]>({
-    queryKey: ["expenses", profile?.id],
+  useEffect(() => { document.title = "Contas a Pagar | Beauty Core"; }, []);
+  const { data: expenses = [], isLoading, error: listError } = useQuery<Expense[]>({
+    queryKey: ["payables", profile?.id], enabled: !!profile?.id,
     queryFn: async () => {
-      if (!profile?.id) return [];
-      const { data } = await supabase
-        .from("expenses")
-        .select("*")
-        .eq("establishment_id", profile.id)
-        .is("deleted_at", null)
-        .order("expense_date", { ascending: false });
-      return (data ?? []) as Expense[];
-    },
-    enabled: !!profile?.id,
-  });
-
-  const filteredExpenses = useMemo(() => {
-    if (recurringFilter === "recurring") return (expenses ?? []).filter((e) => e.recurring_plan_id);
-    if (recurringFilter === "single") return (expenses ?? []).filter((e) => !e.recurring_plan_id);
-    return expenses ?? [];
-  }, [expenses, recurringFilter]);
-
-  const monthTotal = useMemo(() => {
-    if (!expenses) return 0;
-    const now = new Date();
-    return expenses
-      .filter((e) => {
-        const d = new Date(e.expense_date);
-        return d.getMonth() === now.getMonth() && d.getFullYear() === now.getFullYear();
-      })
-      .reduce((sum, e) => sum + Number(e.amount), 0);
-  }, [expenses]);
-
-  const total = useMemo(
-    () => (filteredExpenses ?? []).reduce((s, e) => s + Number(e.amount), 0),
-    [filteredExpenses]
-  );
-
-  const onSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!profile?.id) return;
-    if (!description || !amount) {
-      toast.error("Preencha descrição e valor.");
-      return;
-    }
-    setSubmitting(true);
-    try {
-      const payload = {
-        description,
-        amount: Number(amount),
-        category,
-        notes: notes || null,
-      };
-      const { error } = recurring
-        ? await supabase.rpc("create_financial_recurrence" as never, {
-            p_tenant_id: profile.id,
-            p_tipo: "payable",
-            p_frequency: frequency,
-            p_start_date: format(date, "yyyy-MM-dd"),
-            p_end_date: endMode === "date" && endDate ? endDate : null,
-            p_max_occurrences: endMode === "count" && maxOccurrences ? Number(maxOccurrences) : null,
-            p_template: payload,
-            p_generate_until: endMode === "never" ? format(new Date(date.getFullYear() + 1, date.getMonth(), date.getDate()), "yyyy-MM-dd") : null,
-          } as never)
-        : await supabase.from("expenses").insert({
-            establishment_id: profile.id,
-            ...payload,
-            expense_date: date.toISOString(),
-            status: "confirmed",
-          });
+      // Do not order/filter by new columns on the server: production can briefly run the old schema while migrations propagate.
+      const { data, error } = await supabase.from("expenses").select("*").eq("establishment_id", profile.id).order("expense_date", { ascending: false });
       if (error) throw error;
-      toast.success("Despesa registrada!");
-      setDescription("");
-      setAmount("");
-      setCategory("Outros");
-      setNotes("");
-      setDate(new Date());
-      setRecurring(false);
-      setEndMode("never");
-      setEndDate("");
-      setMaxOccurrences("");
-      qc.invalidateQueries({ queryKey: ["expenses", profile.id] });
-    } catch (err: any) {
-      toast.error(err?.message ?? "Erro ao salvar.");
-    } finally {
-      setSubmitting(false);
-    }
+      return (data ?? []).filter((row: any) => !row.deleted_at).map(normalizeExpense).sort((a, b) => b.due_date.localeCompare(a.due_date));
+    },
+  });
+  useEffect(() => { if (listError) toast.error(`Não foi possível carregar as despesas: ${(listError as Error).message}`); }, [listError]);
+
+  const rows = useMemo(() => expenses.filter((expense) => {
+    const q = filters.q.toLowerCase();
+    return (!q || expense.description.toLowerCase().includes(q) || (expense.supplier || "").toLowerCase().includes(q))
+      && (filters.status === "all" || expense.status === filters.status || (filters.status === "paid" && expense.status === "confirmed"))
+      && (filters.category === "all" || expense.category === filters.category)
+      && (!filters.supplier || (expense.supplier || "").toLowerCase().includes(filters.supplier.toLowerCase()))
+      && (!filters.from || expense.due_date >= filters.from) && (!filters.to || expense.due_date <= filters.to)
+      && (!filters.min || expense.amount >= Number(filters.min)) && (!filters.max || expense.amount <= Number(filters.max));
+  }), [expenses, filters]);
+  const totals = useMemo(() => ({
+    open: expenses.filter((expense) => !["paid", "confirmed", "cancelled"].includes(expense.status)).reduce((sum, expense) => sum + expense.amount - expense.paid_amount, 0),
+    paid: expenses.filter((expense) => ["paid", "confirmed"].includes(expense.status) && isSameMonth(new Date(`${expense.due_date}T12:00:00`), new Date())).reduce((sum, expense) => sum + expense.paid_amount, 0),
+    overdue: expenses.filter((expense) => expense.status === "overdue").reduce((sum, expense) => sum + expense.amount - expense.paid_amount, 0),
+    today: expenses.filter((expense) => expense.status === "due_today").length,
+  }), [expenses]);
+  const invalidate = () => { queryClient.invalidateQueries({ queryKey: ["payables", profile?.id] }); queryClient.invalidateQueries({ queryKey: ["reports"] }); queryClient.invalidateQueries({ queryKey: ["cash-flow"] }); };
+  const changeForm = (field: keyof FormState, value: string) => setForm((current) => ({ ...current, [field]: value }));
+
+  const legacyCreate = async () => {
+    const count = Math.max(1, Number(form.installments)); const total = Number(form.amount); const parcel = Math.round((total / count) * 100) / 100;
+    const records = Array.from({ length: count }, (_, index) => { const due = new Date(`${form.due_date}T12:00:00`); due.setMonth(due.getMonth() + index); return { establishment_id: profile.id, description: count > 1 ? `${form.description} (${index + 1}/${count})` : form.description, amount: index === count - 1 ? total - parcel * (count - 1) : parcel, category: form.category, notes: form.notes || null, expense_date: due.toISOString(), status: "pending" }; });
+    const { error } = await supabase.from("expenses").insert(records); if (error) throw error;
+    toast.warning("Conta salva no modo de compatibilidade. Os dados complementares serão habilitados após a migração do banco.");
   };
-
-  const onDelete = async (item: Expense) => {
-    const future = item.recurring_plan_id && confirm("OK: excluir esta e todas as próximas ocorrências. Cancelar: excluir somente esta ocorrência.");
-    const query = future
-      ? supabase.from("expenses").update({ deleted_at: new Date().toISOString() }).eq("recurring_plan_id", item.recurring_plan_id).gte("expense_date", item.expense_date)
-      : supabase.from("expenses").update({ deleted_at: new Date().toISOString() }).eq("id", item.id);
-    const { error } = await query;
-    if (error) return toast.error(error.message);
-    toast.success("Despesa excluída.");
-    qc.invalidateQueries({ queryKey: ["expenses", profile?.id] });
+  const save = async (event: React.FormEvent) => {
+    event.preventDefault(); if (!canManage || !form.description.trim() || Number(form.amount) <= 0) return toast.error("Informe descrição e valor válido.");
+    setBusy(true);
+    try {
+      const data = { ...form, amount: Number(form.amount) };
+      let result = editing ? await (supabase as any).rpc("update_payable", { p_id: editing.id, p_changes: data }) : await (supabase as any).rpc("create_payables", { p_establishment: profile.id, p_data: data, p_installments: Number(form.installments) });
+      if (result.error && isMissingPayablesSchema(result.error)) {
+        if (editing) result = await supabase.from("expenses").update({ description: form.description, amount: Number(form.amount), category: form.category, notes: form.notes || null, expense_date: new Date(`${form.due_date}T12:00:00`).toISOString() }).eq("id", editing.id);
+        else { await legacyCreate(); result = { error: null }; }
+      }
+      if (result.error) throw result.error;
+      toast.success(editing ? "Despesa atualizada." : "Conta a pagar criada."); setEditing(null); setForm(initialForm()); invalidate();
+    } catch (error: any) { toast.error(error.message); } finally { setBusy(false); }
   };
+  const openEdit = (expense: Expense) => { setEditing(expense); setForm({ description: expense.description, amount: String(expense.amount), category: expense.category || "Outros", supplier: expense.supplier || "", cost_center: expense.cost_center || "Administrativo", notes: expense.notes || "", due_date: expense.due_date, competence_date: expense.competence_date || expense.due_date, installments: String(expense.installment_count || 1) }); };
+  const pay = async () => { if (!paying) return; setBusy(true); try { const { error } = await (supabase as any).rpc("pay_expense", { p_id: paying.id, p_payment_date: payment.date, p_amount: Number(payment.amount), p_method: payment.method, p_account: payment.account, p_interest: Number(payment.interest), p_fine: Number(payment.fine), p_discount: Number(payment.discount), p_notes: payment.notes || null }); if (error) throw error; toast.success("Pagamento registrado e fluxo de caixa atualizado."); setPaying(null); invalidate(); } catch (error: any) { toast.error(error.message); } finally { setBusy(false); } };
+  const remove = async (expense: Expense) => { if (!isOwner || !confirm(`Excluir “${expense.description}”? Movimentações relacionadas também serão removidas.`)) return; const { error } = await (supabase as any).rpc("delete_payable", { p_id: expense.id }); if (error) toast.error(error.message); else { toast.success("Despesa excluída."); invalidate(); } };
 
-  return (
-    <div className="min-h-screen bg-background">
-      <header className="border-b bg-card">
-        <div className="container mx-auto px-4 py-6">
-          <h1 className="text-2xl font-bold">Despesas</h1>
-          <p className="text-muted-foreground">Controle todos os custos do seu salão</p>
-        </div>
-      </header>
-
-      <main className="container mx-auto px-4 py-6 space-y-6">
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium text-muted-foreground">Total no mês</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="flex items-center gap-2">
-                <TrendingDown className="h-5 w-5 text-destructive" />
-                <span className="text-2xl font-bold">R$ {monthTotal.toFixed(2)}</span>
-              </div>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium text-muted-foreground">Total geral</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <span className="text-2xl font-bold">R$ {total.toFixed(2)}</span>
-            </CardContent>
-          </Card>
-        </div>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2"><Plus className="h-5 w-5" /> Nova despesa</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <form onSubmit={onSubmit} className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div className="space-y-2 md:col-span-2">
-                <Label>Descrição</Label>
-                <Input value={description} onChange={(e) => setDescription(e.target.value)} placeholder="Ex.: Conta de luz" />
-              </div>
-              <div className="space-y-2">
-                <Label>Valor (R$)</Label>
-                <Input type="number" step="0.01" min="0" value={amount} onChange={(e) => setAmount(e.target.value)} placeholder="0,00" />
-              </div>
-              <div className="space-y-2">
-                <Label>Categoria</Label>
-                <Select value={category} onValueChange={setCategory}>
-                  <SelectTrigger><SelectValue /></SelectTrigger>
-                  <SelectContent>
-                    {CATEGORIES.map((c) => <SelectItem key={c} value={c}>{c}</SelectItem>)}
-                  </SelectContent>
-                </Select>
-              </div>
-              <div className="space-y-2">
-                <Label>{recurring ? "Data inicial" : "Data"}</Label>
-                <Popover>
-                  <PopoverTrigger asChild>
-                    <Button type="button" variant="outline" className={cn("justify-start", !date && "text-muted-foreground")}>
-                      <CalendarIcon className="mr-2 h-4 w-4" />
-                      {date ? format(date, "dd/MM/yyyy") : "Escolher"}
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent className="w-auto p-0" align="start">
-                    <Calendar mode="single" selected={date} onSelect={(d) => d && setDate(d)} initialFocus className="p-3 pointer-events-auto" />
-                  </PopoverContent>
-                </Popover>
-              </div>
-              <div className="md:col-span-2 rounded-md border p-3 space-y-3">
-                <div className="flex items-center justify-between gap-3">
-                  <Label htmlFor="recurring-expense">Lançamento recorrente</Label>
-                  <Switch id="recurring-expense" checked={recurring} onCheckedChange={setRecurring} />
-                </div>
-                {recurring && (
-                  <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-                    <div className="space-y-2"><Label>Frequência</Label><Select value={frequency} onValueChange={setFrequency}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent>{RECURRENCE_FREQUENCIES.map((f) => <SelectItem key={f.value} value={f.value}>{f.label}</SelectItem>)}</SelectContent></Select></div>
-                    <div className="space-y-2"><Label>Encerramento</Label><Select value={endMode} onValueChange={(v: any) => setEndMode(v)}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent><SelectItem value="never">Recorrência infinita</SelectItem><SelectItem value="date">Até uma data</SelectItem><SelectItem value="count">Quantidade</SelectItem></SelectContent></Select></div>
-                    {endMode === "date" && <div className="space-y-2"><Label>Data final</Label><Input type="date" value={endDate} onChange={(e) => setEndDate(e.target.value)} /></div>}
-                    {endMode === "count" && <div className="space-y-2"><Label>Gerar ocorrências</Label><Input type="number" min="1" placeholder="12, 24, 60..." value={maxOccurrences} onChange={(e) => setMaxOccurrences(e.target.value)} /></div>}
-                  </div>
-                )}
-              </div>
-              <div className="space-y-2 md:col-span-2">
-                <Label>Observações</Label>
-                <Textarea value={notes} onChange={(e) => setNotes(e.target.value)} rows={2} />
-              </div>
-              <div className="md:col-span-2">
-                <Button type="submit" disabled={submitting}>
-                  {submitting ? "Salvando..." : "Registrar despesa"}
-                </Button>
-              </div>
-            </form>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center justify-between gap-3"><span>Histórico</span><Select value={recurringFilter} onValueChange={(v: any) => setRecurringFilter(v)}><SelectTrigger className="w-[210px]"><SelectValue /></SelectTrigger><SelectContent><SelectItem value="all">Todas</SelectItem><SelectItem value="recurring">Apenas recorrentes</SelectItem><SelectItem value="single">Apenas não recorrentes</SelectItem></SelectContent></Select></CardTitle>
-          </CardHeader>
-          <CardContent>
-            {filteredExpenses.length === 0 ? (
-              <p className="text-sm text-muted-foreground">Nenhuma despesa registrada ainda.</p>
-            ) : (
-              <div className="space-y-2">
-                {filteredExpenses.map((e) => (
-                  <div key={e.id} className="flex items-center justify-between gap-3 rounded-md border p-3 hover:bg-muted/40 transition-colors">
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2 flex-wrap">
-                        <span className="font-medium truncate">{e.description}</span>
-                        {e.category && <Badge variant="secondary">{e.category}</Badge>}
-                        {e.recurring_plan_id && <Badge variant="outline" className="gap-1"><Repeat className="h-3 w-3" /> Recorrente</Badge>}
-                        {e.status === "pending" && <Badge variant="outline">Pendente</Badge>}
-                      </div>
-                      <div className="text-xs text-muted-foreground mt-0.5">
-                        {format(new Date(e.expense_date), "dd 'de' MMM yyyy", { locale: ptBR })}
-                        {e.notes && ` • ${e.notes}`}
-                      </div>
-                    </div>
-                    <div className="text-right">
-                      <div className="font-semibold text-destructive">R$ {Number(e.amount).toFixed(2)}</div>
-                    </div>
-                    <Button variant="ghost" size="icon" onClick={() => onDelete(e)}>
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </div>
-                ))}
-              </div>
-            )}
-          </CardContent>
-        </Card>
-      </main>
-    </div>
-  );
+  return <div className="min-h-screen bg-background"><header className="border-b bg-card"><div className="container mx-auto px-4 py-6"><h1 className="text-2xl font-bold">Contas a Pagar</h1><p className="text-muted-foreground">Do previsto à quitação, com integração automática ao fluxo de caixa</p></div></header><main className="container mx-auto px-4 py-6 space-y-5">
+    <div className="grid gap-3 grid-cols-2 lg:grid-cols-4"><Metric title="Total em aberto" value={money(totals.open)} icon={WalletCards} /><Metric title="Pago no mês" value={money(totals.paid)} icon={CheckCircle2} /><Metric title="Total vencido" value={money(totals.overdue)} icon={AlertTriangle} /><Metric title="Vencem hoje" value={String(totals.today)} icon={CalendarClock} /></div>
+    {canManage && <Card><CardHeader><CardTitle className="flex gap-2"><Plus className="h-5 w-5" />{editing ? "Editar despesa" : "Nova conta a pagar"}</CardTitle></CardHeader><CardContent><form onSubmit={save} className="grid md:grid-cols-4 gap-3"><div className="md:col-span-2"><FormField label="Descrição" field="description" form={form} onChange={changeForm} /></div><FormField label="Fornecedor" field="supplier" form={form} onChange={changeForm} /><FormField label="Valor total" field="amount" type="number" form={form} onChange={changeForm} /><div className="space-y-1"><Label>Categoria</Label><Select value={form.category} onValueChange={(value) => changeForm("category", value)}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent>{CATEGORIES.map((item) => <SelectItem key={item} value={item}>{item}</SelectItem>)}</SelectContent></Select></div><div className="space-y-1"><Label>Centro de custo</Label><Select value={form.cost_center} onValueChange={(value) => changeForm("cost_center", value)}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent>{CENTERS.map((item) => <SelectItem key={item} value={item}>{item}</SelectItem>)}</SelectContent></Select></div><FormField label="Competência" field="competence_date" type="date" form={form} onChange={changeForm} /><FormField label="Vencimento" field="due_date" type="date" form={form} onChange={changeForm} />{!editing && <FormField label="Parcelas" field="installments" type="number" form={form} onChange={changeForm} />}<div className="md:col-span-3 space-y-1"><Label>Observações</Label><Textarea value={form.notes} onChange={(event) => changeForm("notes", event.target.value)} /></div><div className="md:col-span-4 flex gap-2"><Button disabled={busy}>{busy ? "Salvando..." : "Salvar"}</Button>{editing && <Button type="button" variant="outline" onClick={() => { setEditing(null); setForm(initialForm()); }}>Cancelar</Button>}</div></form></CardContent></Card>}
+    <Card><CardHeader><CardTitle>Contas</CardTitle></CardHeader><CardContent className="space-y-4"><div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-2"><div className="relative"><Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" /><Input className="pl-9" placeholder="Descrição ou fornecedor" value={filters.q} onChange={(event) => setFilters({ ...filters, q: event.target.value })} /></div><Select value={filters.status} onValueChange={(status) => setFilters({ ...filters, status })}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent><SelectItem value="all">Todos os status</SelectItem>{Object.entries(STATUS).filter(([key]) => key !== "confirmed").map(([key, value]) => <SelectItem value={key} key={key}>{value[0]}</SelectItem>)}</SelectContent></Select><Select value={filters.category} onValueChange={(category) => setFilters({ ...filters, category })}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent><SelectItem value="all">Todas as categorias</SelectItem>{CATEGORIES.map((item) => <SelectItem key={item} value={item}>{item}</SelectItem>)}</SelectContent></Select><Input placeholder="Filtrar fornecedor" value={filters.supplier} onChange={(event) => setFilters({ ...filters, supplier: event.target.value })} /><Input type="date" value={filters.from} onChange={(event) => setFilters({ ...filters, from: event.target.value })} /><Input type="date" value={filters.to} onChange={(event) => setFilters({ ...filters, to: event.target.value })} /><Input type="number" placeholder="Valor mínimo" value={filters.min} onChange={(event) => setFilters({ ...filters, min: event.target.value })} /><Input type="number" placeholder="Valor máximo" value={filters.max} onChange={(event) => setFilters({ ...filters, max: event.target.value })} /></div>
+      {isLoading ? <p>Carregando...</p> : rows.length === 0 ? <p className="text-sm text-muted-foreground py-6 text-center">Nenhuma conta encontrada.</p> : <div className="space-y-2">{rows.map((expense) => { const status = STATUS[expense.status] || STATUS.pending; const balance = expense.amount - expense.paid_amount; return <div key={expense.id} className="rounded-lg border p-3 flex flex-col md:flex-row md:items-center gap-3"><div className="flex-1 min-w-0"><div className="flex flex-wrap gap-2 items-center"><b>{expense.description}</b><Badge variant={status[1]}>{status[0]}</Badge>{expense.installment_count && expense.installment_count > 1 && <Badge variant="outline">{expense.installment_number}/{expense.installment_count}</Badge>}</div><p className="text-xs text-muted-foreground mt-1">Vence {format(new Date(`${expense.due_date}T12:00:00`), "dd 'de' MMMM", { locale: ptBR })} · {expense.supplier || "Sem fornecedor"} · {expense.category || "Sem categoria"} · {expense.cost_center || "Sem centro"}</p>{expense.paid_amount > 0 && <p className="text-xs mt-1">Pago {money(expense.paid_amount)} · Saldo {money(balance)}</p>}</div><div className="font-bold text-destructive">{money(expense.amount)}</div>{canManage && <div className="flex gap-1">{!["paid", "confirmed", "cancelled"].includes(expense.status) && <Button size="sm" onClick={() => { setPaying(expense); setPayment((current) => ({ ...current, amount: String(balance) })); }}>Pagar</Button>}{(!["paid", "confirmed"].includes(expense.status) || isOwner) && <Button size="icon" variant="ghost" onClick={() => openEdit(expense)}><Pencil className="h-4 w-4" /></Button>}{isOwner && <Button size="icon" variant="ghost" onClick={() => remove(expense)}><Trash2 className="h-4 w-4" /></Button>}</div>}</div>; })}</div>}</CardContent></Card>
+  </main><Dialog open={!!paying} onOpenChange={(open) => !open && setPaying(null)}><DialogContent><DialogHeader><DialogTitle>Registrar pagamento</DialogTitle></DialogHeader><div className="grid grid-cols-2 gap-3"><PayField label="Data" field="date" type="date" payment={payment} setPayment={setPayment} /><PayField label="Valor da dívida" field="amount" type="number" payment={payment} setPayment={setPayment} /><PayField label="Juros" field="interest" type="number" payment={payment} setPayment={setPayment} /><PayField label="Multa" field="fine" type="number" payment={payment} setPayment={setPayment} /><PayField label="Desconto" field="discount" type="number" payment={payment} setPayment={setPayment} /><div className="space-y-1"><Label>Forma de pagamento</Label><Select value={payment.method} onValueChange={(method) => setPayment({ ...payment, method })}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent>{["pix", "dinheiro", "boleto", "transferência", "cartão"].map((item) => <SelectItem key={item} value={item}>{item}</SelectItem>)}</SelectContent></Select></div><div className="col-span-2"><PayField label="Conta financeira" field="account" payment={payment} setPayment={setPayment} /></div><div className="col-span-2"><PayField label="Observações" field="notes" payment={payment} setPayment={setPayment} /></div><p className="col-span-2 text-sm font-medium">Saída realizada: {money(Number(payment.amount) + Number(payment.interest) + Number(payment.fine) - Number(payment.discount))}</p></div><DialogFooter><Button variant="outline" onClick={() => setPaying(null)}>Cancelar</Button><Button disabled={busy} onClick={pay}>Confirmar pagamento</Button></DialogFooter></DialogContent></Dialog></div>;
 }

--- a/src/pages/Expenses.tsx
+++ b/src/pages/Expenses.tsx
@@ -1,121 +1,312 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useEffect, useMemo, useState } from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { format, isSameMonth } from "date-fns";
-import { ptBR } from "date-fns/locale";
-import { AlertTriangle, CalendarClock, CheckCircle2, Pencil, Plus, Search, Trash2, WalletCards } from "lucide-react";
-import { toast } from "sonner";
 import { useAuth } from "@/hooks/useAuth";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Calendar } from "@/components/ui/calendar";
+import { Calendar as CalendarIcon, Plus, Repeat, Trash2, TrendingDown } from "lucide-react";
+import { format } from "date-fns";
+import { ptBR } from "date-fns/locale";
+import { cn } from "@/lib/utils";
+import { toast } from "sonner";
+import { Switch } from "@/components/ui/switch";
 
-const CATEGORIES = ["Aluguel", "Água", "Energia", "Internet", "Marketing", "Produtos", "Funcionários", "Impostos", "Equipamentos", "Manutenção", "Outros"];
-const CENTERS = ["Administrativo", "Recepção", "Marketing", "Estoque", "Serviços", "Produtos"];
-const STATUS: Record<string, [string, "default" | "secondary" | "destructive" | "outline"]> = {
-  pending: ["Pendente", "secondary"], due_today: ["Vence hoje", "default"], overdue: ["Vencida", "destructive"],
-  partially_paid: ["Parcialmente paga", "outline"], paid: ["Paga", "secondary"], confirmed: ["Paga", "secondary"], cancelled: ["Cancelada", "outline"],
-};
-const money = (value: number) => value.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
-const isMissingPayablesSchema = (error: any) => error?.code === "PGRST202" || /schema cache|create_payables/i.test(error?.message ?? "");
+const RECURRENCE_FREQUENCIES = [
+  { value: "daily", label: "Diário" },
+  { value: "weekly", label: "Semanal" },
+  { value: "biweekly", label: "Quinzenal" },
+  { value: "monthly", label: "Mensal" },
+  { value: "bimonthly", label: "Bimestral" },
+  { value: "quarterly", label: "Trimestral" },
+  { value: "semiannual", label: "Semestral" },
+  { value: "annual", label: "Anual" },
+];
+
+const CATEGORIES = [
+  "Aluguel",
+  "Energia",
+  "Água",
+  "Internet",
+  "Produtos",
+  "Salários",
+  "Marketing",
+  "Manutenção",
+  "Impostos",
+  "Outros",
+];
 
 interface Expense {
-  id: string; description: string; amount: number; paid_amount: number; category: string | null; supplier: string | null;
-  cost_center: string | null; notes: string | null; due_date: string; competence_date: string | null; expense_date: string;
-  status: string; installment_number: number | null; installment_count: number | null; recurring_plan_id: string | null;
-}
-interface FormState { description: string; amount: string; category: string; supplier: string; cost_center: string; notes: string; due_date: string; competence_date: string; installments: string }
-const initialForm = (): FormState => ({ description: "", amount: "", category: "Outros", supplier: "", cost_center: "Administrativo", notes: "", due_date: format(new Date(), "yyyy-MM-dd"), competence_date: format(new Date(), "yyyy-MM-dd"), installments: "1" });
-
-// Kept at module scope: defining this component inside Expenses remounted every input on each render and caused focus loss.
-function FormField({ label, field, type = "text", form, onChange }: { label: string; field: keyof FormState; type?: string; form: FormState; onChange: (field: keyof FormState, value: string) => void }) {
-  return <div className="space-y-1"><Label htmlFor={`expense-${field}`}>{label}</Label><Input id={`expense-${field}`} type={type} step={type === "number" ? "0.01" : undefined} value={form[field]} onChange={(event) => onChange(field, event.target.value)} /></div>;
-}
-function Metric({ title, value, icon: Icon }: any) { return <Card><CardContent className="pt-5 flex justify-between"><div><p className="text-xs text-muted-foreground">{title}</p><p className="text-xl font-bold mt-1">{value}</p></div><Icon className="h-5 w-5 text-primary" /></CardContent></Card>; }
-function PayField({ label, field, payment, setPayment, type = "text" }: any) { return <div className="space-y-1"><Label htmlFor={`payment-${field}`}>{label}</Label><Input id={`payment-${field}`} type={type} step={type === "number" ? "0.01" : undefined} value={payment[field]} onChange={(event) => setPayment((current: any) => ({ ...current, [field]: event.target.value }))} /></div>; }
-
-function normalizeExpense(row: any): Expense {
-  const date = (row.due_date || row.expense_date || "").slice(0, 10);
-  const legacyPaid = row.status === "confirmed" || row.status === "paid";
-  return { ...row, due_date: date, competence_date: row.competence_date || date, paid_amount: Number(row.paid_amount ?? (legacyPaid ? row.amount : 0)), supplier: row.supplier ?? null, cost_center: row.cost_center ?? null, installment_number: row.installment_number ?? null, installment_count: row.installment_count ?? null, recurring_plan_id: row.recurring_plan_id ?? null };
+  id: string;
+  description: string;
+  amount: number;
+  category: string | null;
+  expense_date: string;
+  notes: string | null;
+  recurring_plan_id: string | null;
+  status: string;
+  deleted_at: string | null;
 }
 
 export default function Expenses() {
-  const { profile, establishmentRole } = useAuth();
-  const queryClient = useQueryClient();
-  const canManage = establishmentRole === "owner" || establishmentRole === "admin";
-  const isOwner = establishmentRole === "owner";
-  const [form, setForm] = useState<FormState>(initialForm);
-  const [editing, setEditing] = useState<Expense | null>(null);
-  const [paying, setPaying] = useState<Expense | null>(null);
-  const [busy, setBusy] = useState(false);
-  const [payment, setPayment] = useState({ date: format(new Date(), "yyyy-MM-dd"), amount: "", method: "pix", account: "Caixa principal", interest: "0", fine: "0", discount: "0", notes: "" });
-  const [filters, setFilters] = useState({ q: "", status: "all", category: "all", supplier: "", from: "", to: "", min: "", max: "" });
+  const { profile } = useAuth();
+  const qc = useQueryClient();
 
-  useEffect(() => { document.title = "Contas a Pagar | Beauty Core"; }, []);
-  const { data: expenses = [], isLoading, error: listError } = useQuery<Expense[]>({
-    queryKey: ["payables", profile?.id], enabled: !!profile?.id,
+  useEffect(() => {
+    document.title = "Despesas | Beauty Core";
+  }, []);
+
+  const [description, setDescription] = useState("");
+  const [amount, setAmount] = useState("");
+  const [category, setCategory] = useState("Outros");
+  const [notes, setNotes] = useState("");
+  const [date, setDate] = useState<Date>(new Date());
+  const [submitting, setSubmitting] = useState(false);
+  const [recurring, setRecurring] = useState(false);
+  const [frequency, setFrequency] = useState("monthly");
+  const [endMode, setEndMode] = useState<"never" | "date" | "count">("never");
+  const [endDate, setEndDate] = useState("");
+  const [maxOccurrences, setMaxOccurrences] = useState("");
+  const [recurringFilter, setRecurringFilter] = useState<"all" | "recurring" | "single">("all");
+
+  const { data: expenses } = useQuery<Expense[]>({
+    queryKey: ["expenses", profile?.id],
     queryFn: async () => {
-      // Do not order/filter by new columns on the server: production can briefly run the old schema while migrations propagate.
-      const { data, error } = await supabase.from("expenses").select("*").eq("establishment_id", profile.id).order("expense_date", { ascending: false });
-      if (error) throw error;
-      return (data ?? []).filter((row: any) => !row.deleted_at).map(normalizeExpense).sort((a, b) => b.due_date.localeCompare(a.due_date));
+      if (!profile?.id) return [];
+      const { data } = await supabase
+        .from("expenses")
+        .select("*")
+        .eq("establishment_id", profile.id)
+        .is("deleted_at", null)
+        .order("expense_date", { ascending: false });
+      return (data ?? []) as Expense[];
     },
+    enabled: !!profile?.id,
   });
-  useEffect(() => { if (listError) toast.error(`Não foi possível carregar as despesas: ${(listError as Error).message}`); }, [listError]);
 
-  const rows = useMemo(() => expenses.filter((expense) => {
-    const q = filters.q.toLowerCase();
-    return (!q || expense.description.toLowerCase().includes(q) || (expense.supplier || "").toLowerCase().includes(q))
-      && (filters.status === "all" || expense.status === filters.status || (filters.status === "paid" && expense.status === "confirmed"))
-      && (filters.category === "all" || expense.category === filters.category)
-      && (!filters.supplier || (expense.supplier || "").toLowerCase().includes(filters.supplier.toLowerCase()))
-      && (!filters.from || expense.due_date >= filters.from) && (!filters.to || expense.due_date <= filters.to)
-      && (!filters.min || expense.amount >= Number(filters.min)) && (!filters.max || expense.amount <= Number(filters.max));
-  }), [expenses, filters]);
-  const totals = useMemo(() => ({
-    open: expenses.filter((expense) => !["paid", "confirmed", "cancelled"].includes(expense.status)).reduce((sum, expense) => sum + expense.amount - expense.paid_amount, 0),
-    paid: expenses.filter((expense) => ["paid", "confirmed"].includes(expense.status) && isSameMonth(new Date(`${expense.due_date}T12:00:00`), new Date())).reduce((sum, expense) => sum + expense.paid_amount, 0),
-    overdue: expenses.filter((expense) => expense.status === "overdue").reduce((sum, expense) => sum + expense.amount - expense.paid_amount, 0),
-    today: expenses.filter((expense) => expense.status === "due_today").length,
-  }), [expenses]);
-  const invalidate = () => { queryClient.invalidateQueries({ queryKey: ["payables", profile?.id] }); queryClient.invalidateQueries({ queryKey: ["reports"] }); queryClient.invalidateQueries({ queryKey: ["cash-flow"] }); };
-  const changeForm = (field: keyof FormState, value: string) => setForm((current) => ({ ...current, [field]: value }));
+  const filteredExpenses = useMemo(() => {
+    if (recurringFilter === "recurring") return (expenses ?? []).filter((e) => e.recurring_plan_id);
+    if (recurringFilter === "single") return (expenses ?? []).filter((e) => !e.recurring_plan_id);
+    return expenses ?? [];
+  }, [expenses, recurringFilter]);
 
-  const legacyCreate = async () => {
-    const count = Math.max(1, Number(form.installments)); const total = Number(form.amount); const parcel = Math.round((total / count) * 100) / 100;
-    const records = Array.from({ length: count }, (_, index) => { const due = new Date(`${form.due_date}T12:00:00`); due.setMonth(due.getMonth() + index); return { establishment_id: profile.id, description: count > 1 ? `${form.description} (${index + 1}/${count})` : form.description, amount: index === count - 1 ? total - parcel * (count - 1) : parcel, category: form.category, notes: form.notes || null, expense_date: due.toISOString(), status: "pending" }; });
-    const { error } = await supabase.from("expenses").insert(records); if (error) throw error;
-    toast.warning("Conta salva no modo de compatibilidade. Os dados complementares serão habilitados após a migração do banco.");
-  };
-  const save = async (event: React.FormEvent) => {
-    event.preventDefault(); if (!canManage || !form.description.trim() || Number(form.amount) <= 0) return toast.error("Informe descrição e valor válido.");
-    setBusy(true);
+  const monthTotal = useMemo(() => {
+    if (!expenses) return 0;
+    const now = new Date();
+    return expenses
+      .filter((e) => {
+        const d = new Date(e.expense_date);
+        return d.getMonth() === now.getMonth() && d.getFullYear() === now.getFullYear();
+      })
+      .reduce((sum, e) => sum + Number(e.amount), 0);
+  }, [expenses]);
+
+  const total = useMemo(
+    () => (filteredExpenses ?? []).reduce((s, e) => s + Number(e.amount), 0),
+    [filteredExpenses]
+  );
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!profile?.id) return;
+    if (!description || !amount) {
+      toast.error("Preencha descrição e valor.");
+      return;
+    }
+    setSubmitting(true);
     try {
-      const data = { ...form, amount: Number(form.amount) };
-      let result = editing ? await (supabase as any).rpc("update_payable", { p_id: editing.id, p_changes: data }) : await (supabase as any).rpc("create_payables", { p_establishment: profile.id, p_data: data, p_installments: Number(form.installments) });
-      if (result.error && isMissingPayablesSchema(result.error)) {
-        if (editing) result = await supabase.from("expenses").update({ description: form.description, amount: Number(form.amount), category: form.category, notes: form.notes || null, expense_date: new Date(`${form.due_date}T12:00:00`).toISOString() }).eq("id", editing.id);
-        else { await legacyCreate(); result = { error: null }; }
-      }
-      if (result.error) throw result.error;
-      toast.success(editing ? "Despesa atualizada." : "Conta a pagar criada."); setEditing(null); setForm(initialForm()); invalidate();
-    } catch (error: any) { toast.error(error.message); } finally { setBusy(false); }
+      const payload = {
+        description,
+        amount: Number(amount),
+        category,
+        notes: notes || null,
+      };
+      const { error } = recurring
+        ? await supabase.rpc("create_financial_recurrence" as never, {
+            p_tenant_id: profile.id,
+            p_tipo: "payable",
+            p_frequency: frequency,
+            p_start_date: format(date, "yyyy-MM-dd"),
+            p_end_date: endMode === "date" && endDate ? endDate : null,
+            p_max_occurrences: endMode === "count" && maxOccurrences ? Number(maxOccurrences) : null,
+            p_template: payload,
+            p_generate_until: endMode === "never" ? format(new Date(date.getFullYear() + 1, date.getMonth(), date.getDate()), "yyyy-MM-dd") : null,
+          } as never)
+        : await supabase.from("expenses").insert({
+            establishment_id: profile.id,
+            ...payload,
+            expense_date: date.toISOString(),
+            status: "confirmed",
+          });
+      if (error) throw error;
+      toast.success("Despesa registrada!");
+      setDescription("");
+      setAmount("");
+      setCategory("Outros");
+      setNotes("");
+      setDate(new Date());
+      setRecurring(false);
+      setEndMode("never");
+      setEndDate("");
+      setMaxOccurrences("");
+      qc.invalidateQueries({ queryKey: ["expenses", profile.id] });
+    } catch (err: any) {
+      toast.error(err?.message ?? "Erro ao salvar.");
+    } finally {
+      setSubmitting(false);
+    }
   };
-  const openEdit = (expense: Expense) => { setEditing(expense); setForm({ description: expense.description, amount: String(expense.amount), category: expense.category || "Outros", supplier: expense.supplier || "", cost_center: expense.cost_center || "Administrativo", notes: expense.notes || "", due_date: expense.due_date, competence_date: expense.competence_date || expense.due_date, installments: String(expense.installment_count || 1) }); };
-  const pay = async () => { if (!paying) return; setBusy(true); try { const { error } = await (supabase as any).rpc("pay_expense", { p_id: paying.id, p_payment_date: payment.date, p_amount: Number(payment.amount), p_method: payment.method, p_account: payment.account, p_interest: Number(payment.interest), p_fine: Number(payment.fine), p_discount: Number(payment.discount), p_notes: payment.notes || null }); if (error) throw error; toast.success("Pagamento registrado e fluxo de caixa atualizado."); setPaying(null); invalidate(); } catch (error: any) { toast.error(error.message); } finally { setBusy(false); } };
-  const remove = async (expense: Expense) => { if (!isOwner || !confirm(`Excluir “${expense.description}”? Movimentações relacionadas também serão removidas.`)) return; const { error } = await (supabase as any).rpc("delete_payable", { p_id: expense.id }); if (error) toast.error(error.message); else { toast.success("Despesa excluída."); invalidate(); } };
 
-  return <div className="min-h-screen bg-background"><header className="border-b bg-card"><div className="container mx-auto px-4 py-6"><h1 className="text-2xl font-bold">Contas a Pagar</h1><p className="text-muted-foreground">Do previsto à quitação, com integração automática ao fluxo de caixa</p></div></header><main className="container mx-auto px-4 py-6 space-y-5">
-    <div className="grid gap-3 grid-cols-2 lg:grid-cols-4"><Metric title="Total em aberto" value={money(totals.open)} icon={WalletCards} /><Metric title="Pago no mês" value={money(totals.paid)} icon={CheckCircle2} /><Metric title="Total vencido" value={money(totals.overdue)} icon={AlertTriangle} /><Metric title="Vencem hoje" value={String(totals.today)} icon={CalendarClock} /></div>
-    {canManage && <Card><CardHeader><CardTitle className="flex gap-2"><Plus className="h-5 w-5" />{editing ? "Editar despesa" : "Nova conta a pagar"}</CardTitle></CardHeader><CardContent><form onSubmit={save} className="grid md:grid-cols-4 gap-3"><div className="md:col-span-2"><FormField label="Descrição" field="description" form={form} onChange={changeForm} /></div><FormField label="Fornecedor" field="supplier" form={form} onChange={changeForm} /><FormField label="Valor total" field="amount" type="number" form={form} onChange={changeForm} /><div className="space-y-1"><Label>Categoria</Label><Select value={form.category} onValueChange={(value) => changeForm("category", value)}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent>{CATEGORIES.map((item) => <SelectItem key={item} value={item}>{item}</SelectItem>)}</SelectContent></Select></div><div className="space-y-1"><Label>Centro de custo</Label><Select value={form.cost_center} onValueChange={(value) => changeForm("cost_center", value)}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent>{CENTERS.map((item) => <SelectItem key={item} value={item}>{item}</SelectItem>)}</SelectContent></Select></div><FormField label="Competência" field="competence_date" type="date" form={form} onChange={changeForm} /><FormField label="Vencimento" field="due_date" type="date" form={form} onChange={changeForm} />{!editing && <FormField label="Parcelas" field="installments" type="number" form={form} onChange={changeForm} />}<div className="md:col-span-3 space-y-1"><Label>Observações</Label><Textarea value={form.notes} onChange={(event) => changeForm("notes", event.target.value)} /></div><div className="md:col-span-4 flex gap-2"><Button disabled={busy}>{busy ? "Salvando..." : "Salvar"}</Button>{editing && <Button type="button" variant="outline" onClick={() => { setEditing(null); setForm(initialForm()); }}>Cancelar</Button>}</div></form></CardContent></Card>}
-    <Card><CardHeader><CardTitle>Contas</CardTitle></CardHeader><CardContent className="space-y-4"><div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-2"><div className="relative"><Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" /><Input className="pl-9" placeholder="Descrição ou fornecedor" value={filters.q} onChange={(event) => setFilters({ ...filters, q: event.target.value })} /></div><Select value={filters.status} onValueChange={(status) => setFilters({ ...filters, status })}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent><SelectItem value="all">Todos os status</SelectItem>{Object.entries(STATUS).filter(([key]) => key !== "confirmed").map(([key, value]) => <SelectItem value={key} key={key}>{value[0]}</SelectItem>)}</SelectContent></Select><Select value={filters.category} onValueChange={(category) => setFilters({ ...filters, category })}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent><SelectItem value="all">Todas as categorias</SelectItem>{CATEGORIES.map((item) => <SelectItem key={item} value={item}>{item}</SelectItem>)}</SelectContent></Select><Input placeholder="Filtrar fornecedor" value={filters.supplier} onChange={(event) => setFilters({ ...filters, supplier: event.target.value })} /><Input type="date" value={filters.from} onChange={(event) => setFilters({ ...filters, from: event.target.value })} /><Input type="date" value={filters.to} onChange={(event) => setFilters({ ...filters, to: event.target.value })} /><Input type="number" placeholder="Valor mínimo" value={filters.min} onChange={(event) => setFilters({ ...filters, min: event.target.value })} /><Input type="number" placeholder="Valor máximo" value={filters.max} onChange={(event) => setFilters({ ...filters, max: event.target.value })} /></div>
-      {isLoading ? <p>Carregando...</p> : rows.length === 0 ? <p className="text-sm text-muted-foreground py-6 text-center">Nenhuma conta encontrada.</p> : <div className="space-y-2">{rows.map((expense) => { const status = STATUS[expense.status] || STATUS.pending; const balance = expense.amount - expense.paid_amount; return <div key={expense.id} className="rounded-lg border p-3 flex flex-col md:flex-row md:items-center gap-3"><div className="flex-1 min-w-0"><div className="flex flex-wrap gap-2 items-center"><b>{expense.description}</b><Badge variant={status[1]}>{status[0]}</Badge>{expense.installment_count && expense.installment_count > 1 && <Badge variant="outline">{expense.installment_number}/{expense.installment_count}</Badge>}</div><p className="text-xs text-muted-foreground mt-1">Vence {format(new Date(`${expense.due_date}T12:00:00`), "dd 'de' MMMM", { locale: ptBR })} · {expense.supplier || "Sem fornecedor"} · {expense.category || "Sem categoria"} · {expense.cost_center || "Sem centro"}</p>{expense.paid_amount > 0 && <p className="text-xs mt-1">Pago {money(expense.paid_amount)} · Saldo {money(balance)}</p>}</div><div className="font-bold text-destructive">{money(expense.amount)}</div>{canManage && <div className="flex gap-1">{!["paid", "confirmed", "cancelled"].includes(expense.status) && <Button size="sm" onClick={() => { setPaying(expense); setPayment((current) => ({ ...current, amount: String(balance) })); }}>Pagar</Button>}{(!["paid", "confirmed"].includes(expense.status) || isOwner) && <Button size="icon" variant="ghost" onClick={() => openEdit(expense)}><Pencil className="h-4 w-4" /></Button>}{isOwner && <Button size="icon" variant="ghost" onClick={() => remove(expense)}><Trash2 className="h-4 w-4" /></Button>}</div>}</div>; })}</div>}</CardContent></Card>
-  </main><Dialog open={!!paying} onOpenChange={(open) => !open && setPaying(null)}><DialogContent><DialogHeader><DialogTitle>Registrar pagamento</DialogTitle></DialogHeader><div className="grid grid-cols-2 gap-3"><PayField label="Data" field="date" type="date" payment={payment} setPayment={setPayment} /><PayField label="Valor da dívida" field="amount" type="number" payment={payment} setPayment={setPayment} /><PayField label="Juros" field="interest" type="number" payment={payment} setPayment={setPayment} /><PayField label="Multa" field="fine" type="number" payment={payment} setPayment={setPayment} /><PayField label="Desconto" field="discount" type="number" payment={payment} setPayment={setPayment} /><div className="space-y-1"><Label>Forma de pagamento</Label><Select value={payment.method} onValueChange={(method) => setPayment({ ...payment, method })}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent>{["pix", "dinheiro", "boleto", "transferência", "cartão"].map((item) => <SelectItem key={item} value={item}>{item}</SelectItem>)}</SelectContent></Select></div><div className="col-span-2"><PayField label="Conta financeira" field="account" payment={payment} setPayment={setPayment} /></div><div className="col-span-2"><PayField label="Observações" field="notes" payment={payment} setPayment={setPayment} /></div><p className="col-span-2 text-sm font-medium">Saída realizada: {money(Number(payment.amount) + Number(payment.interest) + Number(payment.fine) - Number(payment.discount))}</p></div><DialogFooter><Button variant="outline" onClick={() => setPaying(null)}>Cancelar</Button><Button disabled={busy} onClick={pay}>Confirmar pagamento</Button></DialogFooter></DialogContent></Dialog></div>;
+  const onDelete = async (item: Expense) => {
+    const future = item.recurring_plan_id && confirm("OK: excluir esta e todas as próximas ocorrências. Cancelar: excluir somente esta ocorrência.");
+    const query = future
+      ? supabase.from("expenses").update({ deleted_at: new Date().toISOString() }).eq("recurring_plan_id", item.recurring_plan_id).gte("expense_date", item.expense_date)
+      : supabase.from("expenses").update({ deleted_at: new Date().toISOString() }).eq("id", item.id);
+    const { error } = await query;
+    if (error) return toast.error(error.message);
+    toast.success("Despesa excluída.");
+    qc.invalidateQueries({ queryKey: ["expenses", profile?.id] });
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="border-b bg-card">
+        <div className="container mx-auto px-4 py-6">
+          <h1 className="text-2xl font-bold">Despesas</h1>
+          <p className="text-muted-foreground">Controle todos os custos do seu salão</p>
+        </div>
+      </header>
+
+      <main className="container mx-auto px-4 py-6 space-y-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground">Total no mês</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="flex items-center gap-2">
+                <TrendingDown className="h-5 w-5 text-destructive" />
+                <span className="text-2xl font-bold">R$ {monthTotal.toFixed(2)}</span>
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground">Total geral</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <span className="text-2xl font-bold">R$ {total.toFixed(2)}</span>
+            </CardContent>
+          </Card>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2"><Plus className="h-5 w-5" /> Nova despesa</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={onSubmit} className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="space-y-2 md:col-span-2">
+                <Label>Descrição</Label>
+                <Input value={description} onChange={(e) => setDescription(e.target.value)} placeholder="Ex.: Conta de luz" />
+              </div>
+              <div className="space-y-2">
+                <Label>Valor (R$)</Label>
+                <Input type="number" step="0.01" min="0" value={amount} onChange={(e) => setAmount(e.target.value)} placeholder="0,00" />
+              </div>
+              <div className="space-y-2">
+                <Label>Categoria</Label>
+                <Select value={category} onValueChange={setCategory}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    {CATEGORIES.map((c) => <SelectItem key={c} value={c}>{c}</SelectItem>)}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label>{recurring ? "Data inicial" : "Data"}</Label>
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <Button type="button" variant="outline" className={cn("justify-start", !date && "text-muted-foreground")}>
+                      <CalendarIcon className="mr-2 h-4 w-4" />
+                      {date ? format(date, "dd/MM/yyyy") : "Escolher"}
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-auto p-0" align="start">
+                    <Calendar mode="single" selected={date} onSelect={(d) => d && setDate(d)} initialFocus className="p-3 pointer-events-auto" />
+                  </PopoverContent>
+                </Popover>
+              </div>
+              <div className="md:col-span-2 rounded-md border p-3 space-y-3">
+                <div className="flex items-center justify-between gap-3">
+                  <Label htmlFor="recurring-expense">Lançamento recorrente</Label>
+                  <Switch id="recurring-expense" checked={recurring} onCheckedChange={setRecurring} />
+                </div>
+                {recurring && (
+                  <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                    <div className="space-y-2"><Label>Frequência</Label><Select value={frequency} onValueChange={setFrequency}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent>{RECURRENCE_FREQUENCIES.map((f) => <SelectItem key={f.value} value={f.value}>{f.label}</SelectItem>)}</SelectContent></Select></div>
+                    <div className="space-y-2"><Label>Encerramento</Label><Select value={endMode} onValueChange={(v: any) => setEndMode(v)}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent><SelectItem value="never">Recorrência infinita</SelectItem><SelectItem value="date">Até uma data</SelectItem><SelectItem value="count">Quantidade</SelectItem></SelectContent></Select></div>
+                    {endMode === "date" && <div className="space-y-2"><Label>Data final</Label><Input type="date" value={endDate} onChange={(e) => setEndDate(e.target.value)} /></div>}
+                    {endMode === "count" && <div className="space-y-2"><Label>Gerar ocorrências</Label><Input type="number" min="1" placeholder="12, 24, 60..." value={maxOccurrences} onChange={(e) => setMaxOccurrences(e.target.value)} /></div>}
+                  </div>
+                )}
+              </div>
+              <div className="space-y-2 md:col-span-2">
+                <Label>Observações</Label>
+                <Textarea value={notes} onChange={(e) => setNotes(e.target.value)} rows={2} />
+              </div>
+              <div className="md:col-span-2">
+                <Button type="submit" disabled={submitting}>
+                  {submitting ? "Salvando..." : "Registrar despesa"}
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center justify-between gap-3"><span>Histórico</span><Select value={recurringFilter} onValueChange={(v: any) => setRecurringFilter(v)}><SelectTrigger className="w-[210px]"><SelectValue /></SelectTrigger><SelectContent><SelectItem value="all">Todas</SelectItem><SelectItem value="recurring">Apenas recorrentes</SelectItem><SelectItem value="single">Apenas não recorrentes</SelectItem></SelectContent></Select></CardTitle>
+          </CardHeader>
+          <CardContent>
+            {filteredExpenses.length === 0 ? (
+              <p className="text-sm text-muted-foreground">Nenhuma despesa registrada ainda.</p>
+            ) : (
+              <div className="space-y-2">
+                {filteredExpenses.map((e) => (
+                  <div key={e.id} className="flex items-center justify-between gap-3 rounded-md border p-3 hover:bg-muted/40 transition-colors">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="font-medium truncate">{e.description}</span>
+                        {e.category && <Badge variant="secondary">{e.category}</Badge>}
+                        {e.recurring_plan_id && <Badge variant="outline" className="gap-1"><Repeat className="h-3 w-3" /> Recorrente</Badge>}
+                        {e.status === "pending" && <Badge variant="outline">Pendente</Badge>}
+                      </div>
+                      <div className="text-xs text-muted-foreground mt-0.5">
+                        {format(new Date(e.expense_date), "dd 'de' MMM yyyy", { locale: ptBR })}
+                        {e.notes && ` • ${e.notes}`}
+                      </div>
+                    </div>
+                    <div className="text-right">
+                      <div className="font-semibold text-destructive">R$ {Number(e.amount).toFixed(2)}</div>
+                    </div>
+                    <Button variant="ghost" size="icon" onClick={() => onDelete(e)}>
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </main>
+    </div>
+  );
 }

--- a/supabase/migrations/20260727090000_accounts_payable.sql
+++ b/supabase/migrations/20260727090000_accounts_payable.sql
@@ -1,0 +1,165 @@
+-- Complete accounts payable lifecycle. Existing `confirmed` expenses are preserved as paid.
+ALTER TABLE public.expenses DROP CONSTRAINT IF EXISTS expenses_status_check;
+UPDATE public.expenses SET status = 'paid' WHERE status = 'confirmed';
+
+ALTER TABLE public.expenses
+  ADD COLUMN IF NOT EXISTS supplier TEXT,
+  ADD COLUMN IF NOT EXISTS cost_center TEXT,
+  ADD COLUMN IF NOT EXISTS competence_date DATE,
+  ADD COLUMN IF NOT EXISTS due_date DATE,
+  ADD COLUMN IF NOT EXISTS paid_amount NUMERIC(12,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS installment_group_id UUID,
+  ADD COLUMN IF NOT EXISTS installment_number INTEGER,
+  ADD COLUMN IF NOT EXISTS installment_count INTEGER,
+  ADD COLUMN IF NOT EXISTS created_by UUID,
+  ADD COLUMN IF NOT EXISTS paid_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS paid_by UUID,
+  ADD COLUMN IF NOT EXISTS cancelled_at TIMESTAMPTZ;
+
+UPDATE public.expenses
+SET due_date = COALESCE(due_date, expense_date::date),
+    competence_date = COALESCE(competence_date, expense_date::date),
+    paid_amount = CASE WHEN status = 'paid' THEN amount ELSE paid_amount END;
+ALTER TABLE public.expenses ALTER COLUMN due_date SET NOT NULL;
+ALTER TABLE public.expenses ADD CONSTRAINT expenses_status_check
+  CHECK (status IN ('pending','due_today','overdue','partially_paid','paid','cancelled'));
+ALTER TABLE public.expenses ADD CONSTRAINT expenses_paid_amount_check
+  CHECK (paid_amount >= 0 AND paid_amount <= amount);
+
+CREATE TABLE IF NOT EXISTS public.expense_payments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(), expense_id UUID NOT NULL REFERENCES public.expenses(id) ON DELETE CASCADE,
+  establishment_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE, payment_date DATE NOT NULL,
+  amount NUMERIC(12,2) NOT NULL CHECK (amount > 0), interest NUMERIC(12,2) NOT NULL DEFAULT 0 CHECK (interest >= 0),
+  fine NUMERIC(12,2) NOT NULL DEFAULT 0 CHECK (fine >= 0), discount NUMERIC(12,2) NOT NULL DEFAULT 0 CHECK (discount >= 0),
+  final_amount NUMERIC(12,2) GENERATED ALWAYS AS (amount + interest + fine - discount) STORED,
+  payment_method TEXT NOT NULL, financial_account TEXT NOT NULL, notes TEXT, created_by UUID NOT NULL DEFAULT auth.uid(), created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE TABLE IF NOT EXISTS public.expense_audit_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(), expense_id UUID, establishment_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL DEFAULT auth.uid(), operation TEXT NOT NULL CHECK (operation IN ('create','update','payment','delete','cancel')),
+  old_values JSONB, new_values JSONB, created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE TABLE IF NOT EXISTS public.expense_attachments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(), expense_id UUID NOT NULL REFERENCES public.expenses(id) ON DELETE CASCADE,
+  establishment_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE, file_name TEXT NOT NULL, storage_path TEXT NOT NULL,
+  mime_type TEXT NOT NULL CHECK (mime_type IN ('application/pdf','image/jpeg','image/png')), created_by UUID NOT NULL DEFAULT auth.uid(), created_at TIMESTAMPTZ NOT NULL DEFAULT now(), UNIQUE(expense_id, storage_path)
+);
+
+ALTER TABLE public.expense_payments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.expense_audit_logs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.expense_attachments ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Tenant reads expense payments" ON public.expense_payments FOR SELECT USING (establishment_id = public.current_establishment_id());
+CREATE POLICY "Tenant reads expense audit" ON public.expense_audit_logs FOR SELECT USING (establishment_id = public.current_establishment_id());
+CREATE POLICY "Tenant reads expense attachments" ON public.expense_attachments FOR SELECT USING (establishment_id = public.current_establishment_id());
+CREATE POLICY "Managers manage expense attachments" ON public.expense_attachments FOR ALL USING (establishment_id = public.current_establishment_id() AND public.current_establishment_role() IN ('owner','admin')) WITH CHECK (establishment_id = public.current_establishment_id() AND public.current_establishment_role() IN ('owner','admin'));
+
+CREATE INDEX IF NOT EXISTS idx_expenses_payable_filters ON public.expenses(establishment_id, due_date, status) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_expenses_supplier ON public.expenses(establishment_id, supplier) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_expense_payments_expense ON public.expense_payments(expense_id, payment_date);
+CREATE INDEX IF NOT EXISTS idx_expense_audit_expense ON public.expense_audit_logs(expense_id, created_at DESC);
+
+CREATE OR REPLACE FUNCTION public.payable_status(e public.expenses) RETURNS TEXT LANGUAGE sql STABLE AS $$
+ SELECT CASE WHEN e.status = 'cancelled' THEN 'cancelled' WHEN e.paid_amount >= e.amount THEN 'paid'
+   WHEN e.paid_amount > 0 THEN 'partially_paid' WHEN e.due_date < CURRENT_DATE THEN 'overdue'
+   WHEN e.due_date = CURRENT_DATE THEN 'due_today' ELSE 'pending' END
+$$;
+
+CREATE OR REPLACE FUNCTION public.refresh_expense_status() RETURNS TRIGGER LANGUAGE plpgsql AS $$ BEGIN
+  NEW.status := CASE WHEN NEW.status = 'cancelled' THEN 'cancelled' WHEN NEW.paid_amount >= NEW.amount THEN 'paid'
+    WHEN NEW.paid_amount > 0 THEN 'partially_paid' WHEN NEW.due_date < CURRENT_DATE THEN 'overdue'
+    WHEN NEW.due_date = CURRENT_DATE THEN 'due_today' ELSE 'pending' END;
+  RETURN NEW;
+END $$;
+DROP TRIGGER IF EXISTS refresh_expense_status_trigger ON public.expenses;
+CREATE TRIGGER refresh_expense_status_trigger BEFORE INSERT OR UPDATE OF amount, paid_amount, due_date, status ON public.expenses FOR EACH ROW EXECUTE FUNCTION public.refresh_expense_status();
+
+CREATE OR REPLACE FUNCTION public.assert_payable_manager(p_establishment UUID, p_admin_only BOOLEAN DEFAULT false) RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$ BEGIN
+ IF p_establishment <> public.current_establishment_id() OR public.current_establishment_role() NOT IN ('owner','admin') THEN
+   RAISE EXCEPTION 'Sem permissão para alterar contas a pagar';
+ END IF;
+ IF p_admin_only AND public.current_establishment_role() <> 'owner' THEN RAISE EXCEPTION 'Operação exclusiva do administrador'; END IF;
+END $$;
+
+CREATE OR REPLACE FUNCTION public.update_payable(p_id UUID, p_changes JSONB) RETURNS public.expenses
+LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$ DECLARE old_row expenses%ROWTYPE; new_row expenses%ROWTYPE; BEGIN
+ SELECT * INTO old_row FROM expenses WHERE id=p_id AND deleted_at IS NULL FOR UPDATE; IF NOT FOUND THEN RAISE EXCEPTION 'Despesa não encontrada'; END IF;
+ PERFORM assert_payable_manager(old_row.establishment_id, old_row.status='paid');
+ UPDATE expenses SET description=COALESCE(p_changes->>'description',description), supplier=COALESCE(p_changes->>'supplier',supplier),
+ category=COALESCE(p_changes->>'category',category), cost_center=COALESCE(p_changes->>'cost_center',cost_center), notes=COALESCE(p_changes->>'notes',notes),
+ amount=COALESCE((p_changes->>'amount')::numeric,amount), due_date=COALESCE((p_changes->>'due_date')::date,due_date),
+ competence_date=COALESCE((p_changes->>'competence_date')::date,competence_date), expense_date=COALESCE((p_changes->>'due_date')::timestamptz,expense_date)
+ WHERE id=p_id RETURNING * INTO new_row;
+ INSERT INTO expense_audit_logs(expense_id,establishment_id,operation,old_values,new_values) VALUES(p_id,old_row.establishment_id,'update',to_jsonb(old_row),to_jsonb(new_row)); RETURN new_row;
+END $$;
+
+CREATE OR REPLACE FUNCTION public.pay_expense(p_id UUID,p_payment_date DATE,p_amount NUMERIC,p_method TEXT,p_account TEXT,p_interest NUMERIC DEFAULT 0,p_fine NUMERIC DEFAULT 0,p_discount NUMERIC DEFAULT 0,p_notes TEXT DEFAULT NULL) RETURNS public.expenses
+LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$ DECLARE e expenses%ROWTYPE; result expenses%ROWTYPE; pay_id UUID; BEGIN
+ SELECT * INTO e FROM expenses WHERE id=p_id AND deleted_at IS NULL FOR UPDATE; IF NOT FOUND THEN RAISE EXCEPTION 'Despesa não encontrada'; END IF; PERFORM assert_payable_manager(e.establishment_id);
+ IF e.status='cancelled' OR p_amount<=0 OR e.paid_amount+p_amount>e.amount THEN RAISE EXCEPTION 'Pagamento inválido ou superior ao saldo'; END IF;
+ INSERT INTO expense_payments(expense_id,establishment_id,payment_date,amount,interest,fine,discount,payment_method,financial_account,notes)
+ VALUES(p_id,e.establishment_id,p_payment_date,p_amount,COALESCE(p_interest,0),COALESCE(p_fine,0),COALESCE(p_discount,0),p_method,p_account,p_notes) RETURNING id INTO pay_id;
+ UPDATE expenses SET paid_amount=paid_amount+p_amount, paid_at=CASE WHEN paid_amount+p_amount=amount THEN p_payment_date::timestamptz ELSE paid_at END, paid_by=auth.uid() WHERE id=p_id RETURNING * INTO result;
+ INSERT INTO cash_flow_entries(establishment_id,entry_type,category,description,amount,payment_method,status,entry_date,source,source_id,notes)
+ VALUES(e.establishment_id,'expense',COALESCE(e.category,'Despesa'),e.description,p_amount+COALESCE(p_interest,0)+COALESCE(p_fine,0)-COALESCE(p_discount,0),p_method,'confirmed',p_payment_date::timestamptz,'expense_payment',pay_id,p_notes);
+ INSERT INTO expense_audit_logs(expense_id,establishment_id,operation,old_values,new_values) VALUES(p_id,e.establishment_id,'payment',to_jsonb(e),jsonb_build_object('payment_id',pay_id,'expense',to_jsonb(result))); RETURN result;
+END $$;
+
+CREATE OR REPLACE FUNCTION public.delete_payable(p_id UUID) RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$ DECLARE e expenses%ROWTYPE; BEGIN
+ SELECT * INTO e FROM expenses WHERE id=p_id AND deleted_at IS NULL FOR UPDATE; IF NOT FOUND THEN RAISE EXCEPTION 'Despesa não encontrada'; END IF; PERFORM assert_payable_manager(e.establishment_id,true);
+ DELETE FROM cash_flow_entries WHERE (source='expense_payment' AND source_id IN (SELECT id FROM expense_payments WHERE expense_id=p_id)) OR (source='expense' AND source_id=p_id);
+ INSERT INTO expense_audit_logs(expense_id,establishment_id,operation,old_values) VALUES(p_id,e.establishment_id,'delete',to_jsonb(e)); UPDATE expenses SET deleted_at=now() WHERE id=p_id;
+END $$;
+
+-- The legacy trigger now maintains only the forecast; realized payments are inserted by pay_expense.
+CREATE OR REPLACE FUNCTION public.sync_expense_to_cash_flow() RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$ BEGIN
+ IF TG_OP='DELETE' THEN DELETE FROM cash_flow_entries WHERE source='expense' AND source_id=OLD.id; RETURN OLD; END IF;
+ IF NEW.deleted_at IS NOT NULL OR NEW.status IN ('paid','cancelled') THEN DELETE FROM cash_flow_entries WHERE source='expense' AND source_id=NEW.id; RETURN NEW; END IF;
+ INSERT INTO cash_flow_entries(establishment_id,entry_type,category,description,amount,status,entry_date,source,source_id,notes)
+ VALUES(NEW.establishment_id,'expense',COALESCE(NEW.category,'Despesa'),NEW.description,NEW.amount-NEW.paid_amount,'pending',NEW.due_date::timestamptz,'expense',NEW.id,NEW.notes)
+ ON CONFLICT DO NOTHING;
+ UPDATE cash_flow_entries SET amount=NEW.amount-NEW.paid_amount,entry_date=NEW.due_date::timestamptz,description=NEW.description,category=COALESCE(NEW.category,'Despesa'),notes=NEW.notes WHERE source='expense' AND source_id=NEW.id;
+ RETURN NEW; END $$;
+
+ALTER TABLE public.cash_flow_entries DROP CONSTRAINT IF EXISTS cash_flow_entries_source_check;
+ALTER TABLE public.cash_flow_entries ADD CONSTRAINT cash_flow_entries_source_check CHECK(source IN ('sale','expense','expense_payment','appointment_deposit','sale_fee','manual','recurrence'));
+CREATE UNIQUE INDEX IF NOT EXISTS idx_cash_expense_forecast ON public.cash_flow_entries(source,source_id) WHERE source='expense' AND deleted_at IS NULL;
+
+CREATE OR REPLACE FUNCTION public.create_payables(p_establishment UUID,p_data JSONB,p_installments INTEGER DEFAULT 1) RETURNS SETOF public.expenses
+LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$ DECLARE i INTEGER; gid UUID := CASE WHEN p_installments>1 THEN gen_random_uuid() END; base_amount NUMERIC; parcel NUMERIC; due DATE; row expenses%ROWTYPE; BEGIN
+ PERFORM assert_payable_manager(p_establishment); IF p_installments<1 OR p_installments>360 THEN RAISE EXCEPTION 'Quantidade de parcelas inválida'; END IF;
+ base_amount := (p_data->>'amount')::numeric; IF base_amount<=0 THEN RAISE EXCEPTION 'Valor inválido'; END IF; parcel := round(base_amount/p_installments,2);
+ FOR i IN 1..p_installments LOOP
+  due := (p_data->>'due_date')::date + make_interval(months=>i-1);
+  INSERT INTO expenses(establishment_id,description,amount,category,supplier,cost_center,notes,due_date,competence_date,expense_date,status,installment_group_id,installment_number,installment_count,created_by)
+  VALUES(p_establishment,CASE WHEN p_installments>1 THEN (p_data->>'description')||' ('||i||'/'||p_installments||')' ELSE p_data->>'description' END,
+   CASE WHEN i=p_installments THEN base_amount-parcel*(p_installments-1) ELSE parcel END,p_data->>'category',NULLIF(p_data->>'supplier',''),NULLIF(p_data->>'cost_center',''),NULLIF(p_data->>'notes',''),due,COALESCE((p_data->>'competence_date')::date,due),due::timestamptz,'pending',gid,i,p_installments,auth.uid()) RETURNING * INTO row;
+  INSERT INTO expense_audit_logs(expense_id,establishment_id,operation,new_values) VALUES(row.id,p_establishment,'create',to_jsonb(row)); RETURN NEXT row;
+ END LOOP; RETURN;
+END $$;
+
+GRANT EXECUTE ON FUNCTION public.create_payables(UUID,JSONB,INTEGER) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.update_payable(UUID,JSONB) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.pay_expense(UUID,DATE,NUMERIC,TEXT,TEXT,NUMERIC,NUMERIC,NUMERIC,TEXT) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.delete_payable(UUID) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.refresh_expense_status() RETURNS TRIGGER LANGUAGE plpgsql AS $$ BEGIN
+  NEW.due_date := COALESCE(NEW.due_date, NEW.expense_date::date);
+  NEW.competence_date := COALESCE(NEW.competence_date, NEW.expense_date::date);
+  NEW.status := CASE WHEN NEW.status = 'cancelled' THEN 'cancelled' WHEN NEW.paid_amount >= NEW.amount THEN 'paid'
+    WHEN NEW.paid_amount > 0 THEN 'partially_paid' WHEN NEW.due_date < CURRENT_DATE THEN 'overdue'
+    WHEN NEW.due_date = CURRENT_DATE THEN 'due_today' ELSE 'pending' END;
+  RETURN NEW;
+END $$;
+DROP TRIGGER IF EXISTS trg_expenses_cash_flow ON public.expenses;
+DROP TRIGGER IF EXISTS sync_expense_cash_flow ON public.expenses;
+DROP TRIGGER IF EXISTS sync_expense_to_cash_flow_trigger ON public.expenses;
+CREATE TRIGGER sync_expense_cash_flow AFTER INSERT OR UPDATE OR DELETE ON public.expenses FOR EACH ROW EXECUTE FUNCTION public.sync_expense_to_cash_flow();
+
+CREATE OR REPLACE FUNCTION public.refresh_due_expense_statuses() RETURNS INTEGER LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$ DECLARE n INTEGER; BEGIN
+ UPDATE expenses SET status=CASE WHEN due_date=CURRENT_DATE THEN 'due_today' ELSE 'overdue' END
+ WHERE deleted_at IS NULL AND paid_amount=0 AND status NOT IN ('paid','cancelled') AND due_date<=CURRENT_DATE;
+ GET DIAGNOSTICS n=ROW_COUNT; RETURN n; END $$;
+SELECT cron.schedule('refresh-payables-status-daily','1 0 * * *',$$SELECT public.refresh_due_expense_statuses();$$)
+WHERE NOT EXISTS(SELECT 1 FROM cron.job WHERE jobname='refresh-payables-status-daily');
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20260727180000_repair_accounts_payable_rpc.sql
+++ b/supabase/migrations/20260727180000_repair_accounts_payable_rpc.sql
@@ -1,0 +1,70 @@
+-- Repair the API contract after deployments where PostgREST did not expose create_payables.
+-- The explicit drop removes a stale overload with the same argument names/types before recreation.
+DROP FUNCTION IF EXISTS public.create_payables(UUID, JSONB, INTEGER);
+
+CREATE FUNCTION public.create_payables(
+  p_establishment UUID,
+  p_data JSONB,
+  p_installments INTEGER DEFAULT 1
+)
+RETURNS SETOF public.expenses
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  installment_index INTEGER;
+  installment_group UUID := CASE WHEN p_installments > 1 THEN gen_random_uuid() END;
+  total_amount NUMERIC;
+  installment_amount NUMERIC;
+  installment_due_date DATE;
+  created_expense public.expenses%ROWTYPE;
+BEGIN
+  PERFORM public.assert_payable_manager(p_establishment);
+
+  IF p_installments IS NULL OR p_installments < 1 OR p_installments > 360 THEN
+    RAISE EXCEPTION 'Quantidade de parcelas inválida';
+  END IF;
+
+  total_amount := NULLIF(p_data->>'amount', '')::NUMERIC;
+  IF total_amount IS NULL OR total_amount <= 0 THEN
+    RAISE EXCEPTION 'Valor inválido';
+  END IF;
+  IF NULLIF(trim(p_data->>'description'), '') IS NULL THEN
+    RAISE EXCEPTION 'Descrição obrigatória';
+  END IF;
+
+  installment_amount := round(total_amount / p_installments, 2);
+  FOR installment_index IN 1..p_installments LOOP
+    installment_due_date := (p_data->>'due_date')::DATE + make_interval(months => installment_index - 1);
+    INSERT INTO public.expenses (
+      establishment_id, description, amount, category, supplier, cost_center, notes,
+      due_date, competence_date, expense_date, status, installment_group_id,
+      installment_number, installment_count, created_by
+    ) VALUES (
+      p_establishment,
+      CASE WHEN p_installments > 1 THEN (p_data->>'description') || ' (' || installment_index || '/' || p_installments || ')' ELSE p_data->>'description' END,
+      CASE WHEN installment_index = p_installments THEN total_amount - installment_amount * (p_installments - 1) ELSE installment_amount END,
+      NULLIF(p_data->>'category', ''), NULLIF(p_data->>'supplier', ''), NULLIF(p_data->>'cost_center', ''), NULLIF(p_data->>'notes', ''),
+      installment_due_date, COALESCE(NULLIF(p_data->>'competence_date', '')::DATE, installment_due_date), installment_due_date::TIMESTAMPTZ,
+      'pending', installment_group, installment_index, p_installments, auth.uid()
+    ) RETURNING * INTO created_expense;
+
+    INSERT INTO public.expense_audit_logs (expense_id, establishment_id, operation, new_values)
+    VALUES (created_expense.id, p_establishment, 'create', to_jsonb(created_expense));
+    RETURN NEXT created_expense;
+  END LOOP;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.create_payables(UUID, JSONB, INTEGER) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.create_payables(UUID, JSONB, INTEGER) TO authenticated;
+
+-- Preserve all legacy rows and make the compatibility fields deterministic if a partial deploy occurred.
+UPDATE public.expenses
+SET due_date = COALESCE(due_date, expense_date::DATE),
+    competence_date = COALESCE(competence_date, expense_date::DATE),
+    paid_amount = COALESCE(paid_amount, CASE WHEN status IN ('paid', 'confirmed') THEN amount ELSE 0 END)
+WHERE due_date IS NULL OR competence_date IS NULL OR paid_amount IS NULL;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
### Motivation
- Replace the old generic `Expenses` screen with a full-featured accounts payable flow that supports suppliers, cost centers, installments, payments and better status tracking. 
- Introduce a backward-compatible creation path so the UI continues to work while database migrations roll out in production. 

### Description
- Reworked `src/pages/Expenses.tsx` into a modern "Contas a Pagar" UI with new local components (`FormField`, `Metric`, `PayField`), search/filters, summary metrics, payment dialog and inline edit/pay/remove actions. 
- Switched client logic to use new RPCs (`create_payables`, `update_payable`, `pay_expense`, `delete_payable`) with a compatibility fallback that inserts legacy `expenses` rows when the new schema/RPCs are not yet available, and added error handling for schema-mismatch (`isMissingPayablesSchema`). 
- Added richer `Expense` model handling (supplier, cost_center, due_date, competence_date, paid_amount, installments, etc.), status mapping and formatting utilities (`money`, date formatting and `STATUS` mapping). 
- Added two new DB migrations under `supabase/migrations`: `20260727090000_accounts_payable.sql` to add payable columns, tables (`expense_payments`, `expense_audit_logs`, `expense_attachments`), triggers, functions, indexes, policies and a cron job to refresh statuses; and `20260727180000_repair_accounts_payable_rpc.sql` to recreate a stable `create_payables` RPC and make legacy rows deterministic after partial deploys. 

### Testing
- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6779200b60832ea9e436cac7dc5f6d)