### PR TITLE
Corrige confirmação de pagamento em Contas a Pagar

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -662,8 +662,13 @@ export type Database = {
           description: string
           establishment_id: string
           expense_date: string
+          discount: number
+          fine: number
           id: string
+          interest: number
           notes: string | null
+          payment_date: string | null
+          payment_method: string | null
           recurring_plan_id: string | null
           occurrence_date: string | null
           deleted_at: string | null
@@ -677,8 +682,13 @@ export type Database = {
           description: string
           establishment_id: string
           expense_date?: string
+          discount?: number
+          fine?: number
           id?: string
+          interest?: number
           notes?: string | null
+          payment_date?: string | null
+          payment_method?: string | null
           recurring_plan_id?: string | null
           occurrence_date?: string | null
           deleted_at?: string | null
@@ -692,8 +702,13 @@ export type Database = {
           description?: string
           establishment_id?: string
           expense_date?: string
+          discount?: number
+          fine?: number
           id?: string
+          interest?: number
           notes?: string | null
+          payment_date?: string | null
+          payment_method?: string | null
           recurring_plan_id?: string | null
           occurrence_date?: string | null
           deleted_at?: string | null
@@ -1519,6 +1534,20 @@ export type Database = {
       is_establishment_member: {
         Args: { _establishment_id: string; _user_id: string }
         Returns: boolean
+      }
+      pay_expense: {
+        Args: {
+          p_account: string
+          p_amount: number
+          p_discount?: number
+          p_fine?: number
+          p_id: string
+          p_interest?: number
+          p_method: string
+          p_notes?: string | null
+          p_payment_date: string
+        }
+        Returns: Database["public"]["Tables"]["expenses"]["Row"]
       }
       recalculate_sale_commissions: {
         Args: { _establishment_id?: string }

--- a/src/pages/AccountsPayable.tsx
+++ b/src/pages/AccountsPayable.tsx
@@ -85,7 +85,13 @@ export default function Expenses() {
     overdue: expenses.filter((expense) => expense.status === "overdue").reduce((sum, expense) => sum + expense.amount - expense.paid_amount, 0),
     today: expenses.filter((expense) => expense.status === "due_today").length,
   }), [expenses]);
-  const invalidate = () => { queryClient.invalidateQueries({ queryKey: ["payables", profile?.id] }); queryClient.invalidateQueries({ queryKey: ["reports"] }); queryClient.invalidateQueries({ queryKey: ["cash-flow"] }); };
+  const invalidate = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ["payables", profile?.id] }),
+      queryClient.invalidateQueries({ queryKey: ["reports"] }),
+      queryClient.invalidateQueries({ queryKey: ["cash-flow"] }),
+    ]);
+  };
   const changeForm = (field: keyof FormState, value: string) => setForm((current) => ({ ...current, [field]: value }));
 
   const legacyCreate = async () => {
@@ -109,7 +115,24 @@ export default function Expenses() {
     } catch (error: any) { toast.error(error.message); } finally { setBusy(false); }
   };
   const openEdit = (expense: Expense) => { setEditing(expense); setForm({ description: expense.description, amount: String(expense.amount), category: expense.category || "Outros", supplier: expense.supplier || "", cost_center: expense.cost_center || "Administrativo", notes: expense.notes || "", due_date: expense.due_date, competence_date: expense.competence_date || expense.due_date, installments: String(expense.installment_count || 1) }); };
-  const pay = async () => { if (!paying) return; setBusy(true); try { const { error } = await (supabase as any).rpc("pay_expense", { p_id: paying.id, p_payment_date: payment.date, p_amount: Number(payment.amount), p_method: payment.method, p_account: payment.account, p_interest: Number(payment.interest), p_fine: Number(payment.fine), p_discount: Number(payment.discount), p_notes: payment.notes || null }); if (error) throw error; toast.success("Pagamento registrado e fluxo de caixa atualizado."); setPaying(null); invalidate(); } catch (error: any) { toast.error(error.message); } finally { setBusy(false); } };
+  const pay = async () => {
+    if (!paying) return;
+    setBusy(true);
+    try {
+      const { data, error } = await supabase.rpc("pay_expense", {
+        p_id: paying.id, p_payment_date: payment.date, p_amount: Number(payment.amount),
+        p_method: payment.method, p_account: payment.account, p_interest: Number(payment.interest || 0),
+        p_fine: Number(payment.fine || 0), p_discount: Number(payment.discount || 0), p_notes: payment.notes || null,
+      });
+      if (error) throw error;
+      // Apply the returned database row before refetching so pending filters, totals and badges react immediately.
+      queryClient.setQueryData<Expense[]>(["payables", profile?.id], (current = []) =>
+        current.map((expense) => expense.id === paying.id ? normalizeExpense(data) : expense));
+      setPaying(null);
+      await invalidate();
+      toast.success("Pagamento registrado e fluxo de caixa atualizado.");
+    } catch (error: any) { toast.error(error.message); } finally { setBusy(false); }
+  };
   const remove = async (expense: Expense) => { if (!isOwner || !confirm(`Excluir “${expense.description}”? Movimentações relacionadas também serão removidas.`)) return; const { error } = await (supabase as any).rpc("delete_payable", { p_id: expense.id }); if (error) toast.error(error.message); else { toast.success("Despesa excluída."); invalidate(); } };
 
   return <div className="min-h-screen bg-background"><header className="border-b bg-card"><div className="container mx-auto px-4 py-6"><h1 className="text-2xl font-bold">Contas a Pagar</h1><p className="text-muted-foreground">Do previsto à quitação, com integração automática ao fluxo de caixa</p></div></header><main className="container mx-auto px-4 py-6 space-y-5">

--- a/supabase/migrations/20260801090000_repair_pay_expense_rpc.sql
+++ b/supabase/migrations/20260801090000_repair_pay_expense_rpc.sql
@@ -1,0 +1,101 @@
+-- Restore the exact RPC contract used by Contas a Pagar.  Some environments
+-- received the create_payables repair without receiving pay_expense, leaving
+-- PostgREST with no matching function in its schema cache.
+ALTER TABLE public.expenses
+  ADD COLUMN IF NOT EXISTS payment_date DATE,
+  ADD COLUMN IF NOT EXISTS payment_method TEXT,
+  ADD COLUMN IF NOT EXISTS discount NUMERIC(12,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS fine NUMERIC(12,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS interest NUMERIC(12,2) NOT NULL DEFAULT 0;
+
+DROP FUNCTION IF EXISTS public.pay_expense(UUID, DATE, NUMERIC, TEXT, TEXT, NUMERIC, NUMERIC, NUMERIC, TEXT);
+
+CREATE FUNCTION public.pay_expense(
+  p_id UUID,
+  p_payment_date DATE,
+  p_amount NUMERIC,
+  p_method TEXT,
+  p_account TEXT,
+  p_interest NUMERIC DEFAULT 0,
+  p_fine NUMERIC DEFAULT 0,
+  p_discount NUMERIC DEFAULT 0,
+  p_notes TEXT DEFAULT NULL
+)
+RETURNS public.expenses
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  expense_before public.expenses%ROWTYPE;
+  expense_after public.expenses%ROWTYPE;
+  payment_id UUID;
+  interest_amount NUMERIC := COALESCE(p_interest, 0);
+  fine_amount NUMERIC := COALESCE(p_fine, 0);
+  discount_amount NUMERIC := COALESCE(p_discount, 0);
+BEGIN
+  SELECT * INTO expense_before
+  FROM public.expenses
+  WHERE id = p_id AND deleted_at IS NULL
+  FOR UPDATE;
+
+  IF NOT FOUND THEN RAISE EXCEPTION 'Despesa não encontrada'; END IF;
+  PERFORM public.assert_payable_manager(expense_before.establishment_id);
+
+  IF p_payment_date IS NULL OR NULLIF(trim(p_method), '') IS NULL OR NULLIF(trim(p_account), '') IS NULL THEN
+    RAISE EXCEPTION 'Data, forma de pagamento e conta financeira são obrigatórias';
+  END IF;
+  IF expense_before.status = 'cancelled' OR p_amount IS NULL OR p_amount <= 0
+     OR expense_before.paid_amount + p_amount > expense_before.amount
+     OR interest_amount < 0 OR fine_amount < 0 OR discount_amount < 0
+     OR p_amount + interest_amount + fine_amount - discount_amount < 0 THEN
+    RAISE EXCEPTION 'Pagamento inválido ou superior ao saldo';
+  END IF;
+
+  INSERT INTO public.expense_payments (
+    expense_id, establishment_id, payment_date, amount, interest, fine,
+    discount, payment_method, financial_account, notes
+  ) VALUES (
+    p_id, expense_before.establishment_id, p_payment_date, p_amount,
+    interest_amount, fine_amount, discount_amount, p_method, p_account, p_notes
+  ) RETURNING id INTO payment_id;
+
+  UPDATE public.expenses
+  SET paid_amount = paid_amount + p_amount,
+      status = CASE WHEN paid_amount + p_amount >= amount THEN 'paid' ELSE 'partially_paid' END,
+      paid_at = CASE WHEN paid_amount + p_amount >= amount THEN p_payment_date::TIMESTAMPTZ ELSE paid_at END,
+      paid_by = auth.uid(),
+      payment_date = p_payment_date,
+      payment_method = p_method,
+      discount = discount_amount,
+      fine = fine_amount,
+      interest = interest_amount,
+      notes = COALESCE(p_notes, notes),
+      updated_at = now()
+  WHERE id = p_id
+  RETURNING * INTO expense_after;
+
+  INSERT INTO public.cash_flow_entries (
+    establishment_id, entry_type, category, description, amount,
+    payment_method, status, entry_date, source, source_id, notes
+  ) VALUES (
+    expense_before.establishment_id, 'expense', COALESCE(expense_before.category, 'Despesa'),
+    expense_before.description, p_amount + interest_amount + fine_amount - discount_amount,
+    p_method, 'confirmed', p_payment_date::TIMESTAMPTZ, 'expense_payment', payment_id, p_notes
+  );
+
+  INSERT INTO public.expense_audit_logs (
+    expense_id, establishment_id, operation, old_values, new_values
+  ) VALUES (
+    p_id, expense_before.establishment_id, 'payment', to_jsonb(expense_before),
+    jsonb_build_object('payment_id', payment_id, 'expense', to_jsonb(expense_after))
+  );
+
+  RETURN expense_after;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.pay_expense(UUID, DATE, NUMERIC, TEXT, TEXT, NUMERIC, NUMERIC, NUMERIC, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.pay_expense(UUID, DATE, NUMERIC, TEXT, TEXT, NUMERIC, NUMERIC, NUMERIC, TEXT) TO authenticated;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
### Motivation
- Corrigir erro de RPC "Could not find the function public.pay_expense(...)" causado por implantações parciais que deixaram o cache do PostgREST sem a função `pay_expense` com a assinatura esperada. 
- Garantir que, após confirmar um pagamento, a despesa seja atualizada imediatamente (status, valores pagos, data e campos financeiros) sem exigir refresh da página. 

### Description
- Adiciona migration idempotente `supabase/migrations/20260801090000_repair_pay_expense_rpc.sql` que recria explicitamente a função `public.pay_expense(...)` com a assinatura de 9 parâmetros esperada pelo frontend, persiste pagamento em `expense_payments`, atualiza `expenses`, registra `cash_flow_entries` e insere log em `expense_audit_logs`, além de emitir `NOTIFY pgrst, 'reload schema'` para forçar recarga do schema do PostgREST. 
- Atualiza o frontend em `src/pages/AccountsPayable.tsx` para usar a RPC tipada, aplicar imediatamente a linha retornada ao cache do TanStack Query via `queryClient.setQueryData` e aguardar a invalidação de queries com `await invalidate()` para refletir listas, filtros e totais sem refresh. 
- Atualiza os tipos do Supabase em `src/integrations/supabase/types.ts` para incluir os campos de pagamento (`payment_date`, `payment_method`, `discount`, `fine`, `interest`) e para declarar a função RPC `pay_expense` no contrato gerado. 
- Pequeno ajuste de contrato/parametrização para garantir que `p_notes` seja tratado como `null`/`undefined` compatível com o banco. 

### Testing
- Executado `npm run build` com sucesso. 
- Executado `npm run test:security` com todos os testes passando. 
- Executado `npx eslint src/pages/AccountsPayable.tsx src/integrations/supabase/types.ts` sobre os arquivos alterados com sucesso; o lint global do repositório permanece com erros preexistentes fora do escopo desta correção. 
- Executado `git diff --check` e verificado commit limpo; alterações commitadas no commit `fix: restore accounts payable payment flow`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e2f8cd874832ea2dc5445f8676b3d)