### PR TITLE
Preserve negotiated appointment prices; add packages/subscriptions; fix staff creation and lower password min to 6

### DIFF
--- a/src/components/agenda/AppointmentFormDialog.tsx
+++ b/src/components/agenda/AppointmentFormDialog.tsx
@@ -314,13 +314,25 @@ export function AppointmentFormDialog({
       appointmentId = data.id;
     }
 
-    // Replace join rows
+    // Replace join rows with immutable per-service price snapshots. When a custom
+    // total was negotiated, distribute it proportionally (the final item absorbs
+    // rounding), preserving the exact appointment total.
     await supabase.from("appointment_services").delete().eq("appointment_id", appointmentId);
     await supabase.from("appointment_professionals").delete().eq("appointment_id", appointmentId);
     if (form.service_ids.length) {
-      await supabase.from("appointment_services").insert(
-        form.service_ids.map(sid => ({ appointment_id: appointmentId!, service_id: sid, establishment_id: establishmentId }))
-      );
+      const selected = form.service_ids.map(sid => services.find(service => service.id === sid));
+      const catalogTotal = selected.reduce((sum, service) => sum + Number(service?.price ?? 0), 0);
+      const negotiatedTotal = Math.max(0, Number(form.service_amount) || 0);
+      let allocated = 0;
+      await supabase.from("appointment_services").insert(form.service_ids.map((sid, index) => {
+        const catalogPrice = Number(selected[index]?.price ?? 0);
+        const unitPrice = index === form.service_ids.length - 1
+          ? Number((negotiatedTotal - allocated).toFixed(2))
+          : Number((catalogTotal > 0 ? negotiatedTotal * catalogPrice / catalogTotal : negotiatedTotal / form.service_ids.length).toFixed(2));
+        allocated += unitPrice;
+        return { appointment_id: appointmentId!, service_id: sid, establishment_id: establishmentId,
+          unit_price: unitPrice, price_source: Math.abs(negotiatedTotal - catalogTotal) > 0.005 ? "negotiated" : "service" };
+      }) as any);
     }
     if (form.professional_ids.length) {
       await supabase.from("appointment_professionals").insert(

--- a/src/components/users/EditUserDialog.tsx
+++ b/src/components/users/EditUserDialog.tsx
@@ -44,8 +44,8 @@ export function EditUserDialog({ open, onOpenChange, establishmentId, user }: Pr
 
   const onSave = async () => {
     if (!user) return;
-    if (password && password.length < 12) {
-      toast({ title: "Senha inválida", description: "Mínimo 12 caracteres.", variant: "destructive" });
+    if (password && password.length < 6) {
+      toast({ title: "Senha inválida", description: "Mínimo 6 caracteres.", variant: "destructive" });
       return;
     }
     setSaving(true);
@@ -102,7 +102,8 @@ export function EditUserDialog({ open, onOpenChange, establishmentId, user }: Pr
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              placeholder="Mínimo 12 caracteres"
+              placeholder="Mínimo 6 caracteres"
+              minLength={6}
             />
           </div>
 

--- a/src/lib/comanda.ts
+++ b/src/lib/comanda.ts
@@ -23,17 +23,17 @@ export async function ensureComandaForAppointment(opts: {
     .maybeSingle();
   if (existing?.id) return existing.id;
 
-  // Fetch service info
-  const { data: svc } = await supabase
-    .from("services")
-    .select("name, price, commission_solo")
-    .eq("id", service_id)
-    .maybeSingle();
-
-  const unit_price = Number(svc?.price ?? 0);
-  const name = svc?.name ?? "Serviço";
-  const total = unit_price;
-  const commission_pct = Number(svc?.commission_solo ?? 0);
+  const [{ data: appointment }, { data: snapshots }] = await Promise.all([
+    supabase.from("appointments").select("service_amount").eq("id", appointment_id).maybeSingle(),
+    supabase.from("appointment_services").select("service_id, unit_price, services(name, commission_solo)").eq("appointment_id", appointment_id),
+  ]);
+  let pricedServices = (snapshots ?? []) as any[];
+  // Compatibility for appointments created before the snapshot migration.
+  if (!pricedServices.length) {
+    const { data: svc } = await supabase.from("services").select("id, name, price, commission_solo").eq("id", service_id).maybeSingle();
+    pricedServices = [{ service_id, unit_price: appointment?.service_amount ?? svc?.price ?? 0, services: svc }];
+  }
+  const total = pricedServices.reduce((sum, item) => sum + Number(item.unit_price ?? 0), 0);
 
   const { data: comanda, error } = await supabase
     .from("comandas")
@@ -49,19 +49,18 @@ export async function ensureComandaForAppointment(opts: {
     .single();
   if (error) throw error;
 
-  await supabase.from("comanda_items").insert({
-    establishment_id,
-    comanda_id: comanda.id,
-    kind: "service",
-    service_id,
-    name,
-    qty: 1,
-    unit_price,
-    total,
-    professional_id: professional_id ?? null,
-    commission_percentage: commission_pct,
-    commission_amount: total * (commission_pct / 100),
-  });
+  const { error: itemError } = await supabase.from("comanda_items").insert(pricedServices.map(item => {
+    const unitPrice = Number(item.unit_price ?? 0);
+    const commissionPct = Number(item.services?.commission_solo ?? 0);
+    return { establishment_id, comanda_id: comanda.id, kind: "service", service_id: item.service_id,
+      name: item.services?.name ?? "Serviço", qty: 1, unit_price: unitPrice, total: unitPrice,
+      professional_id: professional_id ?? null, commission_percentage: commissionPct,
+      commission_amount: unitPrice * (commissionPct / 100) };
+  }) as any);
+  if (itemError) {
+    await supabase.from("comandas").delete().eq("id", comanda.id);
+    throw itemError;
+  }
 
   return comanda.id;
 }

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -111,10 +111,10 @@ export default function Users() {
       });
       return;
     }
-    if (password.trim().length < 12) {
+    if (password.trim().length < 6) {
       toast({
         title: "Senha inválida",
-        description: "A senha deve ter pelo menos 12 caracteres.",
+        description: "A senha deve ter pelo menos 6 caracteres.",
         variant: "destructive",
       });
       return;
@@ -123,25 +123,17 @@ export default function Users() {
 
     setSaving(true);
     try {
-      const { data: created, error } = await supabase.functions.invoke("create-staff-user", {
+      const { error } = await supabase.functions.invoke("create-staff-user", {
         body: {
           establishment_id: establishmentId,
           email: email.trim().toLowerCase(),
           password: password.trim(),
           name: name.trim(),
           role,
+          service_ids: selectedServices,
         },
       });
       if (error) throw error;
-
-      if (created?.professional_id && selectedServices.length) {
-        const rows = selectedServices.map((service_id) => ({
-          establishment_id: establishmentId,
-          service_id,
-          professional_id: created.professional_id,
-        }));
-        await supabase.from("service_professionals").insert(rows as any);
-      }
 
       toast({ title: "Usuário vinculado" });
       setEmail("");
@@ -350,7 +342,8 @@ export default function Users() {
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              placeholder="Mínimo 12 caracteres"
+              placeholder="Mínimo 6 caracteres"
+              minLength={6}
             />
           </div>
 

--- a/supabase/functions/asaas-webhook/index.ts
+++ b/supabase/functions/asaas-webhook/index.ts
@@ -90,6 +90,7 @@ Deno.serve(async (req) => {
     let establishmentId: string | null = null;
     let localSubId: string | null = null;
     let localSub: { id: string; establishment_id: string; pending_plan_id: string | null } | null = null;
+    let customerServiceSub: { id: string; establishment_id: string } | null = null;
     if (subscriptionId) {
       const { data: sub, error } = await admin.from('subscriptions')
         .select('id, establishment_id, pending_plan_id')
@@ -109,7 +110,35 @@ Deno.serve(async (req) => {
       localSubId = localSub.id;
     }
 
-    if (paymentId && !localSub) {
+    // Customer service plans share the established Asaas webhook and secrets;
+    // they intentionally do not create a second billing integration.
+    if (!localSub && subscriptionId) {
+      const { data, error } = await admin.from('customer_service_subscriptions')
+        .select('id, establishment_id').eq('asaas_subscription_id', subscriptionId).maybeSingle();
+      if (error) throw error;
+      customerServiceSub = data;
+    }
+
+    if (customerServiceSub) {
+      if (event === 'PAYMENT_CONFIRMED' || event === 'PAYMENT_RECEIVED') {
+        const startsAt = payment.dueDate ? new Date(`${payment.dueDate}T00:00:00.000Z`) : new Date();
+        const endsAt = new Date(startsAt);
+        endsAt.setUTCMonth(endsAt.getUTCMonth() + 1);
+        const { error } = await admin.rpc('open_customer_subscription_cycle', {
+          p_subscription_id: customerServiceSub.id, p_starts_at: startsAt.toISOString(),
+          p_ends_at: endsAt.toISOString(), p_asaas_payment_id: paymentId,
+        });
+        if (error) throw error;
+      } else if (event === 'PAYMENT_OVERDUE') {
+        const { error } = await admin.from('customer_service_subscriptions').update({ status: 'past_due', updated_at: new Date().toISOString() }).eq('id', customerServiceSub.id);
+        if (error) throw error;
+      } else if (event === 'PAYMENT_REFUNDED' || event === 'PAYMENT_DELETED') {
+        const { error } = await admin.from('customer_service_subscriptions').update({ status: 'cancelled', cancelled_at: new Date().toISOString(), updated_at: new Date().toISOString() }).eq('id', customerServiceSub.id);
+        if (error) throw error;
+      }
+    }
+
+    if (paymentId && !localSub && !customerServiceSub) {
       throw new Error(
         `Local subscription not found (Asaas subscription: ${subscriptionId ?? 'missing'}, customer: ${customerId ?? 'missing'})`,
       );

--- a/supabase/functions/create-staff-user/index.ts
+++ b/supabase/functions/create-staff-user/index.ts
@@ -4,6 +4,10 @@ import { corsHeaders, isAllowedBrowserOrigin } from "../_shared/cors.ts";
 const MAX_BODY_BYTES = 16 * 1024;
 const ALLOWED_ROLES = new Set(["admin", "employee"]);
 
+class RequestError extends Error {
+  constructor(public code: string, message: string, public status = 400) { super(message); }
+}
+
 Deno.serve(async (req) => {
   const cors = corsHeaders(req);
   if (!isAllowedBrowserOrigin(req)) return new Response(JSON.stringify({ error: "Origin não permitida" }), { status: 403, headers: { ...cors, "Content-Type": "application/json" } });
@@ -13,7 +17,7 @@ Deno.serve(async (req) => {
 
   try {
     const authHeader = req.headers.get("Authorization");
-    if (!authHeader) throw new Error("Authorization ausente");
+    if (!authHeader) throw new RequestError("UNAUTHENTICATED", "Sessão inválida. Entre novamente.", 401);
 
     const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
     const anonKey = Deno.env.get("SUPABASE_ANON_KEY")!;
@@ -23,22 +27,23 @@ Deno.serve(async (req) => {
     const adminClient = createClient(supabaseUrl, serviceKey);
 
     const token = authHeader.replace(/^Bearer\s+/i, "");
-    const { data: claimsData, error: authErr } = await userClient.auth.getClaims(token);
-    const callerId = claimsData?.claims?.sub;
-    if (authErr || !callerId || claimsData?.claims?.role !== "authenticated") {
+    const { data: authData, error: authErr } = await userClient.auth.getUser(token);
+    const callerId = authData.user?.id;
+    if (authErr || !callerId) {
       console.error("auth error", authErr);
-      throw new Error("Usuário não autenticado");
+      throw new RequestError("UNAUTHENTICATED", "Sessão inválida. Entre novamente.", 401);
     }
 
     const rawBody = await req.text();
     if (new TextEncoder().encode(rawBody).byteLength > MAX_BODY_BYTES) throw new Error("Payload muito grande");
     const body = JSON.parse(rawBody);
-    const { establishment_id, email, password, name, role } = body ?? {};
+    const { establishment_id, email, password, name, role, service_ids = [] } = body ?? {};
 
-    if (!establishment_id || !email || !password || !name || !role) throw new Error("Dados obrigatórios ausentes");
-    if (!ALLOWED_ROLES.has(String(role))) throw new Error("Perfil inválido");
-    if (String(password).length < 12) throw new Error("Senha deve ter pelo menos 12 caracteres");
-    if (String(name).trim().length > 120 || String(email).length > 254) throw new Error("Dados inválidos");
+    if (!establishment_id || !email || !password || !name || !role) throw new RequestError("INVALID_INPUT", "Preencha todos os campos obrigatórios.");
+    if (!ALLOWED_ROLES.has(String(role))) throw new RequestError("INVALID_ROLE", "Perfil inválido.");
+    if (String(password).length < 6) throw new RequestError("WEAK_PASSWORD", "A senha deve ter pelo menos 6 caracteres.");
+    if (String(name).trim().length > 120 || String(email).length > 254) throw new RequestError("INVALID_INPUT", "Dados inválidos.");
+    if (!Array.isArray(service_ids) || service_ids.length > 200 || service_ids.some((id) => typeof id !== "string")) throw new RequestError("INVALID_INPUT", "Serviços inválidos.");
 
     const { data: ownerProfile } = await adminClient.from("profiles").select("id").eq("id", establishment_id).eq("user_id", callerId).maybeSingle();
     let canManage = !!ownerProfile;
@@ -53,7 +58,7 @@ Deno.serve(async (req) => {
         .maybeSingle();
       canManage = !!adminMembership;
     }
-    if (!canManage) throw new Error("Sem permissão para gerenciar usuários deste estabelecimento");
+    if (!canManage) throw new RequestError("FORBIDDEN", "Você não tem permissão para gerenciar usuários desta loja.", 403);
 
     const normalizedEmail = String(email).trim().toLowerCase();
 
@@ -70,31 +75,57 @@ Deno.serve(async (req) => {
     });
 
     if (createErr) {
-      if (!createErr.message?.toLowerCase().includes("already")) throw createErr;
+      const duplicate = /already|registered|exists/i.test(createErr.message ?? "");
+      throw new RequestError(duplicate ? "EMAIL_EXISTS" : "AUTH_CREATE_FAILED", duplicate ? "Este e-mail já está cadastrado." : "Não foi possível criar o acesso do funcionário.", duplicate ? 409 : 502);
     }
-
-    let userId = createdUser.user?.id;
-    if (!userId) {
-      const { data: list } = await adminClient.auth.admin.listUsers({ page: 1, perPage: 1000 });
-      const matched = list.users.find((u) => u.email?.toLowerCase() === normalizedEmail);
-      userId = matched?.id;
-    }
-    if (!userId) throw new Error("Não foi possível localizar usuário criado");
+    const userId = createdUser.user?.id;
+    if (!userId) throw new RequestError("AUTH_CREATE_FAILED", "Não foi possível criar o acesso do funcionário.", 502);
 
     const { data: professional, error: profErr } = await adminClient
       .from("professionals")
       .insert({ establishment_id, name: String(name).trim(), active: true })
       .select("id")
       .single();
-    if (profErr) throw profErr;
+    if (profErr) {
+      await adminClient.auth.admin.deleteUser(userId);
+      console.error("professional creation failed", profErr);
+      throw new RequestError("PROFILE_CREATE_FAILED", "O acesso não foi criado porque o perfil profissional não pôde ser salvo.", 500);
+    }
 
     const { error: linkErr } = await adminClient
       .from("establishment_users")
       .upsert({ establishment_id, user_id: userId, role, professional_id: professional.id, active: true, email: normalizedEmail }, { onConflict: "establishment_id,user_id" });
-    if (linkErr) throw linkErr;
+    if (linkErr) {
+      await adminClient.from("professionals").delete().eq("id", professional.id);
+      await adminClient.auth.admin.deleteUser(userId);
+      console.error("membership creation failed", linkErr);
+      throw new RequestError("MEMBERSHIP_CREATE_FAILED", "O acesso não foi criado porque o vínculo com a loja não pôde ser salvo.", 500);
+    }
+
+    if (service_ids.length) {
+      const { data: allowedServices, error: servicesError } = await adminClient.from("services").select("id").eq("establishment_id", establishment_id).in("id", service_ids);
+      if (servicesError || allowedServices?.length !== new Set(service_ids).size) {
+        await adminClient.from("establishment_users").delete().eq("establishment_id", establishment_id).eq("user_id", userId);
+        await adminClient.from("professionals").delete().eq("id", professional.id);
+        await adminClient.auth.admin.deleteUser(userId);
+        throw new RequestError("INVALID_SERVICES", "Um ou mais serviços selecionados são inválidos.");
+      }
+      const { error: assignmentsError } = await adminClient.from("service_professionals").insert(
+        [...new Set(service_ids)].map((service_id) => ({ establishment_id, service_id, professional_id: professional.id })),
+      );
+      if (assignmentsError) {
+        await adminClient.from("establishment_users").delete().eq("establishment_id", establishment_id).eq("user_id", userId);
+        await adminClient.from("professionals").delete().eq("id", professional.id);
+        await adminClient.auth.admin.deleteUser(userId);
+        console.error("service assignments failed", assignmentsError);
+        throw new RequestError("PROFILE_CREATE_FAILED", "O acesso não foi criado porque as permissões profissionais não puderam ser salvas.", 500);
+      }
+    }
 
     return new Response(JSON.stringify({ user_id: userId, professional_id: professional.id }), { headers: { ...cors, "Content-Type": "application/json" } });
   } catch (e: any) {
-    return new Response(JSON.stringify({ error: e.message ?? "Erro" }), { status: 400, headers: { ...cors, "Content-Type": "application/json" } });
+    const known = e instanceof RequestError;
+    if (!known) console.error("create-staff-user unexpected error", e);
+    return new Response(JSON.stringify({ code: known ? e.code : "INTERNAL_ERROR", error: known ? e.message : "Não foi possível cadastrar o funcionário." }), { status: known ? e.status : 500, headers: { ...cors, "Content-Type": "application/json" } });
   }
 });

--- a/supabase/functions/update-staff-user/index.ts
+++ b/supabase/functions/update-staff-user/index.ts
@@ -74,7 +74,7 @@ Deno.serve(async (req) => {
     const normalizedEmail = email && String(email).trim() ? String(email).trim().toLowerCase() : undefined;
     if (normalizedEmail) authUpdates.email = normalizedEmail;
     if (password && String(password).length > 0) {
-      if (String(password).length < 12) throw new Error("Senha deve ter pelo menos 12 caracteres");
+      if (String(password).length < 6) throw new Error("Senha deve ter pelo menos 6 caracteres");
       authUpdates.password = String(password);
     }
     if (Object.keys(authUpdates).length > 0) {

--- a/supabase/migrations/20260827090000_service_benefits_and_price_snapshots.sql
+++ b/supabase/migrations/20260827090000_service_benefits_and_price_snapshots.sql
@@ -1,0 +1,196 @@
+-- Historical appointment pricing and customer service benefits.
+-- Additive migration: no operational or financial records are deleted.
+ALTER TABLE public.appointment_services
+  ADD COLUMN IF NOT EXISTS unit_price numeric(12,2),
+  ADD COLUMN IF NOT EXISTS price_source text NOT NULL DEFAULT 'service'
+    CHECK (price_source IN ('service','negotiated')),
+  ADD COLUMN IF NOT EXISTS benefit_type text CHECK (benefit_type IN ('package','subscription')),
+  ADD COLUMN IF NOT EXISTS benefit_credit_id uuid;
+
+-- Preserve the best historical value available. For legacy single-service appointments,
+-- service_amount is the historical snapshot; only otherwise fall back to catalog price.
+UPDATE public.appointment_services aps
+SET unit_price = CASE
+  WHEN a.service_amount IS NOT NULL AND (SELECT count(*) FROM public.appointment_services x WHERE x.appointment_id = aps.appointment_id) = 1
+    THEN a.service_amount
+  ELSE s.price
+END,
+price_source = CASE WHEN a.service_amount IS NOT NULL THEN 'negotiated' ELSE 'service' END
+FROM public.appointments a, public.services s
+WHERE a.id = aps.appointment_id AND s.id = aps.service_id AND aps.unit_price IS NULL;
+ALTER TABLE public.appointment_services ALTER COLUMN unit_price SET NOT NULL;
+ALTER TABLE public.appointment_services ADD CONSTRAINT appointment_services_unit_price_nonnegative CHECK (unit_price >= 0) NOT VALID;
+ALTER TABLE public.appointment_services VALIDATE CONSTRAINT appointment_services_unit_price_nonnegative;
+
+-- Price snapshots already copied to a comanda cannot be silently edited.
+CREATE OR REPLACE FUNCTION public.guard_appointment_service_financial_snapshot()
+RETURNS trigger LANGUAGE plpgsql SET search_path = public AS $$
+BEGIN
+  IF (TG_OP = 'DELETE' OR OLD.unit_price IS DISTINCT FROM NEW.unit_price) AND EXISTS (
+    SELECT 1 FROM public.comandas c WHERE c.appointment_id = OLD.appointment_id
+  ) THEN RAISE EXCEPTION 'O valor não pode ser alterado após a criação da comanda'; END IF;
+  RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+END $$;
+DROP TRIGGER IF EXISTS guard_appointment_service_financial_snapshot ON public.appointment_services;
+CREATE TRIGGER guard_appointment_service_financial_snapshot BEFORE UPDATE OR DELETE ON public.appointment_services
+FOR EACH ROW EXECUTE FUNCTION public.guard_appointment_service_financial_snapshot();
+
+CREATE TABLE public.service_packages (
+ id uuid PRIMARY KEY DEFAULT gen_random_uuid(), establishment_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+ name text NOT NULL CHECK (length(trim(name)) BETWEEN 1 AND 120), description text,
+ price numeric(12,2) NOT NULL CHECK(price >= 0), validity_days integer NOT NULL CHECK(validity_days > 0),
+ status text NOT NULL DEFAULT 'active' CHECK(status IN ('active','inactive')),
+ created_at timestamptz NOT NULL DEFAULT now(), updated_at timestamptz NOT NULL DEFAULT now(), UNIQUE(establishment_id,name)
+);
+CREATE TABLE public.service_package_items (
+ id uuid PRIMARY KEY DEFAULT gen_random_uuid(), establishment_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+ package_id uuid NOT NULL REFERENCES public.service_packages(id) ON DELETE CASCADE,
+ service_id uuid NOT NULL REFERENCES public.services(id) ON DELETE RESTRICT, quantity integer NOT NULL CHECK(quantity > 0),
+ created_at timestamptz NOT NULL DEFAULT now(), UNIQUE(package_id,service_id)
+);
+CREATE TABLE public.customer_packages (
+ id uuid PRIMARY KEY DEFAULT gen_random_uuid(), establishment_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+ client_id uuid NOT NULL REFERENCES public.clients(id) ON DELETE RESTRICT, package_id uuid NOT NULL REFERENCES public.service_packages(id) ON DELETE RESTRICT,
+ purchased_at timestamptz NOT NULL DEFAULT now(), starts_at timestamptz NOT NULL DEFAULT now(), expires_at timestamptz NOT NULL,
+ amount_paid numeric(12,2) NOT NULL CHECK(amount_paid >= 0), status text NOT NULL DEFAULT 'active' CHECK(status IN ('pending','active','expired','cancelled')),
+ sale_id uuid REFERENCES public.sales(id) ON DELETE SET NULL, created_by uuid REFERENCES auth.users(id) ON DELETE SET NULL, created_at timestamptz NOT NULL DEFAULT now(),
+ CHECK(expires_at > starts_at)
+);
+CREATE TABLE public.customer_package_credits (
+ id uuid PRIMARY KEY DEFAULT gen_random_uuid(), establishment_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+ customer_package_id uuid NOT NULL REFERENCES public.customer_packages(id) ON DELETE CASCADE,
+ service_id uuid NOT NULL REFERENCES public.services(id) ON DELETE RESTRICT, contracted integer NOT NULL CHECK(contracted > 0), used integer NOT NULL DEFAULT 0 CHECK(used >= 0 AND used <= contracted),
+ UNIQUE(customer_package_id,service_id)
+);
+
+CREATE TABLE public.customer_subscription_plans (
+ id uuid PRIMARY KEY DEFAULT gen_random_uuid(), establishment_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+ name text NOT NULL CHECK(length(trim(name)) BETWEEN 1 AND 120), description text, price numeric(12,2) NOT NULL CHECK(price >= 0),
+ periodicity text NOT NULL DEFAULT 'monthly' CHECK(periodicity IN ('monthly')), status text NOT NULL DEFAULT 'active' CHECK(status IN ('active','inactive')),
+ created_at timestamptz NOT NULL DEFAULT now(), updated_at timestamptz NOT NULL DEFAULT now(), UNIQUE(establishment_id,name)
+);
+CREATE TABLE public.customer_subscription_plan_items (
+ id uuid PRIMARY KEY DEFAULT gen_random_uuid(), establishment_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+ plan_id uuid NOT NULL REFERENCES public.customer_subscription_plans(id) ON DELETE CASCADE,
+ service_id uuid NOT NULL REFERENCES public.services(id) ON DELETE RESTRICT, quantity integer NOT NULL CHECK(quantity > 0), UNIQUE(plan_id,service_id)
+);
+CREATE TABLE public.customer_service_subscriptions (
+ id uuid PRIMARY KEY DEFAULT gen_random_uuid(), establishment_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+ client_id uuid NOT NULL REFERENCES public.clients(id) ON DELETE RESTRICT, plan_id uuid NOT NULL REFERENCES public.customer_subscription_plans(id) ON DELETE RESTRICT,
+ status text NOT NULL DEFAULT 'pending' CHECK(status IN ('pending','active','past_due','cancelled')),
+ starts_at timestamptz NOT NULL DEFAULT now(), next_renewal_at timestamptz, cancelled_at timestamptz,
+ asaas_customer_id text, asaas_subscription_id text UNIQUE, billing_reference text,
+ created_by uuid REFERENCES auth.users(id) ON DELETE SET NULL, created_at timestamptz NOT NULL DEFAULT now(), updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE TABLE public.customer_subscription_cycles (
+ id uuid PRIMARY KEY DEFAULT gen_random_uuid(), establishment_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+ subscription_id uuid NOT NULL REFERENCES public.customer_service_subscriptions(id) ON DELETE CASCADE,
+ starts_at timestamptz NOT NULL, ends_at timestamptz NOT NULL, status text NOT NULL DEFAULT 'pending' CHECK(status IN ('pending','active','closed','cancelled')),
+ asaas_payment_id text UNIQUE, paid_at timestamptz, created_at timestamptz NOT NULL DEFAULT now(), CHECK(ends_at > starts_at), UNIQUE(subscription_id,starts_at)
+);
+CREATE TABLE public.customer_subscription_credits (
+ id uuid PRIMARY KEY DEFAULT gen_random_uuid(), establishment_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+ cycle_id uuid NOT NULL REFERENCES public.customer_subscription_cycles(id) ON DELETE CASCADE,
+ service_id uuid NOT NULL REFERENCES public.services(id) ON DELETE RESTRICT, contracted integer NOT NULL CHECK(contracted > 0), used integer NOT NULL DEFAULT 0 CHECK(used >= 0 AND used <= contracted), UNIQUE(cycle_id,service_id)
+);
+CREATE TABLE public.service_benefit_consumptions (
+ id uuid PRIMARY KEY DEFAULT gen_random_uuid(), establishment_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+ client_id uuid NOT NULL REFERENCES public.clients(id) ON DELETE RESTRICT, service_id uuid NOT NULL REFERENCES public.services(id) ON DELETE RESTRICT,
+ benefit_type text NOT NULL CHECK(benefit_type IN ('package','subscription')), package_credit_id uuid REFERENCES public.customer_package_credits(id) ON DELETE RESTRICT,
+ subscription_credit_id uuid REFERENCES public.customer_subscription_credits(id) ON DELETE RESTRICT,
+ appointment_id uuid REFERENCES public.appointments(id) ON DELETE RESTRICT, comanda_id uuid REFERENCES public.comandas(id) ON DELETE RESTRICT,
+ professional_id uuid REFERENCES public.professionals(id) ON DELETE SET NULL, reference_value numeric(12,2) NOT NULL CHECK(reference_value >= 0),
+ consumed_at timestamptz NOT NULL DEFAULT now(), consumed_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+ reversed_at timestamptz, reversed_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+ CHECK ((benefit_type='package' AND package_credit_id IS NOT NULL AND subscription_credit_id IS NULL) OR (benefit_type='subscription' AND subscription_credit_id IS NOT NULL AND package_credit_id IS NULL))
+);
+ALTER TABLE public.comanda_items
+  ADD COLUMN IF NOT EXISTS payment_source text NOT NULL DEFAULT 'normal' CHECK(payment_source IN ('normal','package','subscription','client_credit')),
+  ADD COLUMN IF NOT EXISTS reference_unit_price numeric(12,2),
+  ADD COLUMN IF NOT EXISTS benefit_consumption_id uuid REFERENCES public.service_benefit_consumptions(id) ON DELETE RESTRICT;
+CREATE UNIQUE INDEX service_benefit_one_active_consumption_per_appointment_service ON public.service_benefit_consumptions(appointment_id,service_id) WHERE reversed_at IS NULL AND appointment_id IS NOT NULL;
+CREATE INDEX service_packages_tenant ON public.service_packages(establishment_id,status);
+CREATE INDEX customer_packages_client ON public.customer_packages(establishment_id,client_id,status,expires_at);
+CREATE INDEX customer_subscriptions_client ON public.customer_service_subscriptions(establishment_id,client_id,status);
+CREATE INDEX benefit_consumptions_history ON public.service_benefit_consumptions(establishment_id,client_id,consumed_at DESC);
+
+-- Verify denormalized tenant keys on every write; prevents cross-tenant FK composition even for service-role callers.
+CREATE OR REPLACE FUNCTION public.validate_service_benefit_tenant() RETURNS trigger LANGUAGE plpgsql SET search_path=public AS $$
+DECLARE expected uuid;
+BEGIN
+ CASE TG_TABLE_NAME
+ WHEN 'service_package_items' THEN SELECT establishment_id INTO expected FROM service_packages WHERE id=NEW.package_id;
+ WHEN 'customer_packages' THEN SELECT establishment_id INTO expected FROM clients WHERE id=NEW.client_id;
+ WHEN 'customer_package_credits' THEN SELECT establishment_id INTO expected FROM customer_packages WHERE id=NEW.customer_package_id;
+ WHEN 'customer_subscription_plan_items' THEN SELECT establishment_id INTO expected FROM customer_subscription_plans WHERE id=NEW.plan_id;
+ WHEN 'customer_service_subscriptions' THEN SELECT establishment_id INTO expected FROM clients WHERE id=NEW.client_id;
+ WHEN 'customer_subscription_cycles' THEN SELECT establishment_id INTO expected FROM customer_service_subscriptions WHERE id=NEW.subscription_id;
+ WHEN 'customer_subscription_credits' THEN SELECT establishment_id INTO expected FROM customer_subscription_cycles WHERE id=NEW.cycle_id;
+ WHEN 'service_benefit_consumptions' THEN SELECT establishment_id INTO expected FROM clients WHERE id=NEW.client_id;
+ END CASE;
+ IF expected IS NULL OR expected <> NEW.establishment_id THEN RAISE EXCEPTION 'Referência entre estabelecimentos não permitida'; END IF;
+ IF TG_TABLE_NAME IN ('service_package_items','customer_package_credits','customer_subscription_plan_items','customer_subscription_credits','service_benefit_consumptions')
+    AND NOT EXISTS(SELECT 1 FROM services WHERE id=NEW.service_id AND establishment_id=NEW.establishment_id)
+ THEN RAISE EXCEPTION 'Serviço de outro estabelecimento'; END IF;
+ RETURN NEW;
+END $$;
+DO $$ DECLARE t text; BEGIN FOREACH t IN ARRAY ARRAY['service_package_items','customer_packages','customer_package_credits','customer_subscription_plan_items','customer_service_subscriptions','customer_subscription_cycles','customer_subscription_credits','service_benefit_consumptions'] LOOP EXECUTE format('CREATE TRIGGER validate_tenant BEFORE INSERT OR UPDATE ON public.%I FOR EACH ROW EXECUTE FUNCTION public.validate_service_benefit_tenant()',t); END LOOP; END $$;
+
+-- Atomic package sale: snapshot package contents into credits.
+CREATE OR REPLACE FUNCTION public.sell_service_package(p_package_id uuid,p_client_id uuid,p_amount_paid numeric DEFAULT NULL,p_starts_at timestamptz DEFAULT now(),p_sale_id uuid DEFAULT NULL)
+RETURNS uuid LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE p service_packages; result uuid;
+BEGIN SELECT * INTO p FROM service_packages WHERE id=p_package_id AND status='active'; IF NOT FOUND THEN RAISE EXCEPTION 'Pacote indisponível'; END IF;
+ IF NOT is_establishment_member(p.establishment_id,auth.uid()) THEN RAISE EXCEPTION 'Sem permissão'; END IF;
+ IF NOT EXISTS(SELECT 1 FROM clients WHERE id=p_client_id AND establishment_id=p.establishment_id) THEN RAISE EXCEPTION 'Cliente inválido'; END IF;
+ INSERT INTO customer_packages(establishment_id,client_id,package_id,starts_at,expires_at,amount_paid,sale_id,created_by)
+ VALUES(p.establishment_id,p_client_id,p.id,p_starts_at,p_starts_at+make_interval(days=>p.validity_days),coalesce(p_amount_paid,p.price),p_sale_id,auth.uid()) RETURNING id INTO result;
+ INSERT INTO customer_package_credits(establishment_id,customer_package_id,service_id,contracted)
+ SELECT p.establishment_id,result,service_id,quantity FROM service_package_items WHERE package_id=p.id;
+ IF NOT FOUND THEN RAISE EXCEPTION 'Pacote sem serviços'; END IF; RETURN result; END $$;
+
+CREATE OR REPLACE FUNCTION public.open_customer_subscription_cycle(p_subscription_id uuid,p_starts_at timestamptz,p_ends_at timestamptz,p_asaas_payment_id text DEFAULT NULL)
+RETURNS uuid LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE s customer_service_subscriptions; result uuid;
+BEGIN SELECT * INTO s FROM customer_service_subscriptions WHERE id=p_subscription_id FOR UPDATE; IF NOT FOUND THEN RAISE EXCEPTION 'Assinatura não encontrada'; END IF;
+ IF auth.uid() IS NOT NULL AND NOT is_establishment_member(s.establishment_id,auth.uid()) AND NOT has_role(auth.uid(),'super_admin') THEN RAISE EXCEPTION 'Sem permissão'; END IF;
+ UPDATE customer_subscription_cycles SET status='closed' WHERE subscription_id=s.id AND status='active';
+ INSERT INTO customer_subscription_cycles(establishment_id,subscription_id,starts_at,ends_at,status,asaas_payment_id,paid_at) VALUES(s.establishment_id,s.id,p_starts_at,p_ends_at,'active',p_asaas_payment_id,now()) ON CONFLICT(subscription_id,starts_at) DO UPDATE SET status='active',paid_at=coalesce(customer_subscription_cycles.paid_at,now()),asaas_payment_id=coalesce(EXCLUDED.asaas_payment_id,customer_subscription_cycles.asaas_payment_id) RETURNING id INTO result;
+ INSERT INTO customer_subscription_credits(establishment_id,cycle_id,service_id,contracted) SELECT s.establishment_id,result,i.service_id,i.quantity FROM customer_subscription_plan_items i WHERE i.plan_id=s.plan_id ON CONFLICT(cycle_id,service_id) DO NOTHING;
+ UPDATE customer_service_subscriptions SET status='active',next_renewal_at=p_ends_at,updated_at=now() WHERE id=s.id; RETURN result; END $$;
+
+-- Atomic, idempotent consumption. Credits are only consumed for a completed appointment or an open comanda.
+CREATE OR REPLACE FUNCTION public.consume_service_benefit(p_client_id uuid,p_service_id uuid,p_benefit_type text,p_credit_id uuid,p_appointment_id uuid DEFAULT NULL,p_comanda_id uuid DEFAULT NULL,p_professional_id uuid DEFAULT NULL,p_reference_value numeric DEFAULT 0)
+RETURNS uuid LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE est uuid; result uuid; remaining int;
+BEGIN SELECT establishment_id INTO est FROM clients WHERE id=p_client_id; IF est IS NULL OR NOT is_establishment_member(est,auth.uid()) THEN RAISE EXCEPTION 'Sem permissão'; END IF;
+ IF p_appointment_id IS NULL AND p_comanda_id IS NULL THEN RAISE EXCEPTION 'Atendimento ou comanda obrigatório'; END IF;
+ IF p_appointment_id IS NOT NULL AND NOT EXISTS(SELECT 1 FROM appointments WHERE id=p_appointment_id AND establishment_id=est AND client_id=p_client_id AND status NOT IN ('scheduled','canceled')) THEN RAISE EXCEPTION 'Atendimento ainda não realizado ou cancelado'; END IF;
+ IF p_benefit_type='package' THEN
+   SELECT c.contracted-c.used INTO remaining FROM customer_package_credits c JOIN customer_packages x ON x.id=c.customer_package_id WHERE c.id=p_credit_id AND c.service_id=p_service_id AND x.client_id=p_client_id AND x.establishment_id=est AND x.status='active' AND now() BETWEEN x.starts_at AND x.expires_at FOR UPDATE OF c;
+   IF coalesce(remaining,0)<1 THEN RAISE EXCEPTION 'Crédito de pacote indisponível'; END IF; UPDATE customer_package_credits SET used=used+1 WHERE id=p_credit_id;
+   INSERT INTO service_benefit_consumptions(establishment_id,client_id,service_id,benefit_type,package_credit_id,appointment_id,comanda_id,professional_id,reference_value,consumed_by) VALUES(est,p_client_id,p_service_id,'package',p_credit_id,p_appointment_id,p_comanda_id,p_professional_id,p_reference_value,auth.uid()) RETURNING id INTO result;
+ ELSIF p_benefit_type='subscription' THEN
+   SELECT c.contracted-c.used INTO remaining FROM customer_subscription_credits c JOIN customer_subscription_cycles y ON y.id=c.cycle_id JOIN customer_service_subscriptions s ON s.id=y.subscription_id WHERE c.id=p_credit_id AND c.service_id=p_service_id AND s.client_id=p_client_id AND s.establishment_id=est AND s.status='active' AND y.status='active' AND now() BETWEEN y.starts_at AND y.ends_at FOR UPDATE OF c;
+   IF coalesce(remaining,0)<1 THEN RAISE EXCEPTION 'Crédito de assinatura indisponível'; END IF; UPDATE customer_subscription_credits SET used=used+1 WHERE id=p_credit_id;
+   INSERT INTO service_benefit_consumptions(establishment_id,client_id,service_id,benefit_type,subscription_credit_id,appointment_id,comanda_id,professional_id,reference_value,consumed_by) VALUES(est,p_client_id,p_service_id,'subscription',p_credit_id,p_appointment_id,p_comanda_id,p_professional_id,p_reference_value,auth.uid()) RETURNING id INTO result;
+ ELSE RAISE EXCEPTION 'Tipo de benefício inválido'; END IF;
+ IF p_comanda_id IS NOT NULL THEN
+   UPDATE comanda_items SET reference_unit_price=coalesce(reference_unit_price,unit_price), unit_price=0, total=0,
+     commission_amount=0, payment_source=p_benefit_type, benefit_consumption_id=result
+   WHERE comanda_id=p_comanda_id AND service_id=p_service_id AND establishment_id=est AND benefit_consumption_id IS NULL;
+   IF NOT FOUND THEN RAISE EXCEPTION 'Item da comanda não encontrado ou benefício já aplicado'; END IF;
+   UPDATE comandas SET subtotal=(SELECT coalesce(sum(total),0) FROM comanda_items WHERE comanda_id=p_comanda_id),
+     total=greatest(0,(SELECT coalesce(sum(total),0) FROM comanda_items WHERE comanda_id=p_comanda_id)-coalesce(discount,0)),updated_at=now()
+   WHERE id=p_comanda_id AND establishment_id=est;
+ END IF;
+ RETURN result;
+EXCEPTION WHEN unique_violation THEN RAISE EXCEPTION 'Benefício já consumido para este serviço do atendimento'; END $$;
+
+-- Tenant RLS: members read operational data; only owner/admin manage definitions and sales. Consumption only via RPC.
+DO $$ DECLARE t text; BEGIN FOREACH t IN ARRAY ARRAY['service_packages','service_package_items','customer_packages','customer_package_credits','customer_subscription_plans','customer_subscription_plan_items','customer_service_subscriptions','customer_subscription_cycles','customer_subscription_credits','service_benefit_consumptions'] LOOP EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY',t); EXECUTE format('GRANT SELECT ON public.%I TO authenticated',t); EXECUTE format('CREATE POLICY tenant_read ON public.%I FOR SELECT TO authenticated USING (is_establishment_member(establishment_id,auth.uid()) OR has_role(auth.uid(),''super_admin''))',t); END LOOP; END $$;
+CREATE POLICY tenant_manage_packages ON public.service_packages FOR ALL TO authenticated USING(current_establishment_role() IN ('owner','admin') AND establishment_id=current_establishment_id()) WITH CHECK(current_establishment_role() IN ('owner','admin') AND establishment_id=current_establishment_id());
+CREATE POLICY tenant_manage_package_items ON public.service_package_items FOR ALL TO authenticated USING(current_establishment_role() IN ('owner','admin') AND establishment_id=current_establishment_id()) WITH CHECK(current_establishment_role() IN ('owner','admin') AND establishment_id=current_establishment_id());
+CREATE POLICY tenant_manage_plans ON public.customer_subscription_plans FOR ALL TO authenticated USING(current_establishment_role() IN ('owner','admin') AND establishment_id=current_establishment_id()) WITH CHECK(current_establishment_role() IN ('owner','admin') AND establishment_id=current_establishment_id());
+CREATE POLICY tenant_manage_plan_items ON public.customer_subscription_plan_items FOR ALL TO authenticated USING(current_establishment_role() IN ('owner','admin') AND establishment_id=current_establishment_id()) WITH CHECK(current_establishment_role() IN ('owner','admin') AND establishment_id=current_establishment_id());
+GRANT EXECUTE ON FUNCTION public.sell_service_package(uuid,uuid,numeric,timestamptz,uuid), public.open_customer_subscription_cycle(uuid,timestamptz,timestamptz,text), public.consume_service_benefit(uuid,uuid,text,uuid,uuid,uuid,uuid,numeric) TO authenticated;

--- a/tests/beauty-core-contract.test.mjs
+++ b/tests/beauty-core-contract.test.mjs
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+const read = path => readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+
+test('staff password validation is consistently six characters', () => {
+  for (const path of ['src/pages/Users.tsx','src/components/users/EditUserDialog.tsx','supabase/functions/create-staff-user/index.ts','supabase/functions/update-staff-user/index.ts']) {
+    const source = read(path);
+    assert.match(source, /length < 6|minLength=\{6\}/, path);
+    assert.doesNotMatch(source, /12 caracteres|length < 12|minLength=\{12\}/, path);
+  }
+});
+
+test('staff creation never adopts a pre-existing auth identity and compensates failed writes', () => {
+  const source = read('supabase/functions/create-staff-user/index.ts');
+  assert.match(source, /EMAIL_EXISTS/);
+  assert.doesNotMatch(source, /listUsers/);
+  assert.match(source, /deleteUser\(userId\)/);
+  assert.match(source, /MEMBERSHIP_CREATE_FAILED/);
+});
+
+test('comanda is seeded from per-service appointment price snapshots', () => {
+  const source = read('src/lib/comanda.ts');
+  assert.match(source, /appointment_services/);
+  assert.match(source, /unit_price/);
+  assert.match(source, /pricedServices\.map/);
+  assert.doesNotMatch(source, /const unit_price = Number\(svc\?\.price/);
+});
+
+test('benefit migration provides tenant RLS and atomic idempotent consumption', () => {
+  const source = read('supabase/migrations/20260827090000_service_benefits_and_price_snapshots.sql');
+  for (const token of ['service_packages','customer_packages','customer_service_subscriptions','customer_subscription_cycles','service_benefit_consumptions','ENABLE ROW LEVEL SECURITY','FOR UPDATE OF c','service_benefit_one_active_consumption']) assert.ok(source.includes(token), token);
+  assert.match(source, /status NOT IN \('scheduled','canceled'\)/);
+  assert.match(source, /open_customer_subscription_cycle/);
+});
+
+test('Asaas webhook activates customer subscription cycles', () => {
+  const source = read('supabase/functions/asaas-webhook/index.ts');
+  assert.match(source, /customer_service_subscriptions/);
+  assert.match(source, /open_customer_subscription_cycle/);
+  assert.match(source, /past_due/);
+});


### PR DESCRIPTION
### Motivation

- Fix root cause of staff creation failures (atomicity, unsafe reuse of existing Auth identities) and improve user-facing error handling.
- Preserve negotiated/negotiated-per-service appointment prices so comandas always reflect the appointment snapshot instead of catalog prices.
- Add package and subscription model to support one-off packages and monthly plans with credit/franchise tracking and secure multi-tenant RLS.
- Standardize password minimum to 6 characters across frontend, backend and Edge Functions.

### Description

- Edge Functions: reworked `create-staff-user` (validated session with `auth.getUser`, structured `RequestError`, atomic flow that creates Auth user → professional → establishment_user → optional `service_professionals` assignments and compensates (deletes) partial writes on failure), improved error codes/messages and input validation; similarly lowered min password check to 6 in `update-staff-user`. (files: `supabase/functions/create-staff-user/index.ts`, `supabase/functions/update-staff-user/index.ts`)
- Frontend user flows: lowered UI validation to 6 chars and added `minLength` on inputs; pass selected `service_ids` to staff creation Edge Function so assignments are created server-side. (files: `src/pages/Users.tsx`, `src/components/users/EditUserDialog.tsx`)
- Appointment / Comanda pricing: added per-service `unit_price` snapshot to `appointment_services`, backfilled from `appointments.service_amount` for legacy single-service appointments, and made comanda creation read snapshots instead of catalog price; appointment form now writes per-service `unit_price` and, when a negotiated total exists for multi-service appointments, it distributes the negotiated total proportionally (last item absorbs rounding). Comanda seeding inserts items using snapshots and deletes the created comanda on insertion error to avoid partial state. (files: `supabase/migrations/20260827090000_service_benefits_and_price_snapshots.sql`, `src/components/agenda/AppointmentFormDialog.tsx`, `src/lib/comanda.ts`)
- Packages & Subscriptions: migration creates tables for `service_packages`, `service_package_items`, `customer_packages`, `customer_package_credits`, `customer_subscription_plans`, `customer_subscription_plan_items`, `customer_service_subscriptions`, `customer_subscription_cycles`, `customer_subscription_credits`, and `service_benefit_consumptions`; includes RPCs `sell_service_package`, `open_customer_subscription_cycle` and `consume_service_benefit` (atomic, idempotent consumption with `FOR UPDATE` locking), tenant triggers/validation and RLS policies. Also added `comanda_items` columns to track `payment_source`, `reference_unit_price` and `benefit_consumption_id`. (file: `supabase/migrations/20260827090000_service_benefits_and_price_snapshots.sql`)
- Webhook: extended existing Asaas webhook to handle `customer_service_subscriptions` by calling `open_customer_subscription_cycle` on payment confirm and updating subscription status on overdue/refund events; reused existing webhook and secrets. (file: `supabase/functions/asaas-webhook/index.ts`)
- Data protection: guard trigger prevents editing/deleting price snapshots for appointment services that already have an associated comanda to preserve financial audit trail. (migration file above)
- Misc: added lightweight contract tests validating the main invariants implemented (password min length consistency, staff creation compensation, comanda snapshot usage, migration features). (file: `tests/beauty-core-contract.test.mjs`)

### Testing

- Ran contract and unit checks: `node --test tests/beauty-core-contract.test.mjs` — all contract assertions passed (password validations, staff creation safety, comanda snapshots, RLS/consumption, Asaas webhook coverage). (pass)
- Ran security and suite checks: `node --test tests/security-hardening.test.mjs` — passed. (pass)
- Ran finance tests: `npm run test:finance` — existing finance scenarios passed (no regressions in cash/commission logic). (pass)
- Build: `npm run build` — production build succeeded. (pass)
- Lint: `npm run lint` — reported many pre-existing issues in the repository (mostly `any` usages and generated code); those are unrelated to the functional changes and remain outstanding. (warning)
- Notes and cautions: migration and RPCs were added as a safe additive migration file `supabase/migrations/20260827090000_service_benefits_and_price_snapshots.sql`; automated tests here did not run against a live Supabase/Postgres/Asaas sandbox (no credentials in environment), so final integration verification (apply migration against a staging DB, run end-to-end flows: create staff, create appointments with negotiated totals, open comanda, sell package, consume credit, Asaas payment lifecycle) should be executed in a staging environment before production deployment.

Files of primary interest changed/added in this PR: `supabase/functions/create-staff-user/index.ts`, `supabase/functions/update-staff-user/index.ts`, `supabase/functions/asaas-webhook/index.ts`, `supabase/migrations/20260827090000_service_benefits_and_price_snapshots.sql`, `src/components/agenda/AppointmentFormDialog.tsx`, `src/lib/comanda.ts`, `src/pages/Users.tsx`, `src/components/users/EditUserDialog.tsx`, `tests/beauty-core-contract.test.mjs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8fb23bfaa4832ea8a9e229a2543ac2)